### PR TITLE
fix(model): decouple certificates and private key

### DIFF
--- a/benches/authly_benches.rs
+++ b/benches/authly_benches.rs
@@ -1,8 +1,7 @@
 use authly::{
     access_token,
-    cert::{key_pair, MakeSigningRequest},
+    ctx::{test::TestCtx, GetInstance},
     session::{Session, SessionToken},
-    TlsParams,
 };
 use authly_common::id::{Eid, ObjId};
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -10,9 +9,7 @@ use fnv::FnvHashSet;
 use time::{Duration, OffsetDateTime};
 
 pub fn authly_benchmark(c: &mut Criterion) {
-    let local_ca = key_pair().authly_ca().self_signed();
-    let identity = key_pair().authly_ca().self_signed();
-    let tls_params = TlsParams::from_keys(local_ca, identity);
+    let ctx = TestCtx::default().supreme_instance();
     let session = Session {
         token: SessionToken::new_random(),
         eid: Eid::random(),
@@ -22,8 +19,12 @@ pub fn authly_benchmark(c: &mut Criterion) {
 
     c.bench_function("generate_access_token", |b| {
         b.iter(|| {
-            access_token::create_access_token(&session, user_attributes.clone(), &tls_params)
-                .unwrap();
+            access_token::create_access_token(
+                &session,
+                user_attributes.clone(),
+                ctx.get_instance(),
+            )
+            .unwrap();
         })
     });
 }

--- a/migrations/1_init.sql
+++ b/migrations/1_init.sql
@@ -12,12 +12,21 @@ CREATE TABLE cr_prop_dek (
     created_at DATETIME NOT NULL
 );
 
-CREATE TABLE tlskey (
-    purpose TEXT NOT NULL PRIMARY KEY,
+CREATE TABLE authly_instance (
+    key TEXT NOT NULL PRIMARY KEY,
+    eid BLOB NOT NULL,
+    private_key_nonce BLOB NOT NULL,
+    private_key_ciph BLOB NOT NULL
+);
+
+CREATE TABLE tls_cert (
+    -- CA or identity
+    kind TEXT NOT NULL,
+    certifies_eid BLOB NOT NULL,
+    signed_by_eid BLOB NOT NULL,
+    created_at DATETIME NOT NULL,
     expires_at DATETIME NOT NULL,
-    cert BLOB NOT NULL,
-    key_nonce BLOB NOT NULL,
-    key_ciph BLOB NOT NULL
+    der BLOB NOT NULL
 );
 
 -- Any kind of authority, including other Authly Authorities

--- a/src/access_token.rs
+++ b/src/access_token.rs
@@ -18,7 +18,7 @@ use axum_extra::{
 use fnv::FnvHashSet;
 use http::{request::Parts, StatusCode};
 
-use crate::{session::Session, AuthlyCtx, TlsParams};
+use crate::{instance::AuthlyInstance, session::Session, AuthlyCtx};
 
 const EXPIRATION: time::Duration = time::Duration::days(365);
 
@@ -36,7 +36,7 @@ pub enum AccessTokenError {
 pub fn create_access_token(
     session: &Session,
     user_attributes: FnvHashSet<ObjId>,
-    tls_params: &TlsParams,
+    instance: &AuthlyInstance,
 ) -> Result<String, AccessTokenError> {
     let jwt_header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);
     let now = time::OffsetDateTime::now_utc();
@@ -50,21 +50,19 @@ pub fn create_access_token(
             entity_attributes: user_attributes,
         },
     };
-    let encoding_key =
-        jsonwebtoken::EncodingKey::from_ec_der(tls_params.local_ca.key.serialized_der());
 
-    jsonwebtoken::encode(&jwt_header, &claims, &encoding_key)
+    jsonwebtoken::encode(&jwt_header, &claims, &instance.local_jwt_encoding_key())
         .map_err(|_| AccessTokenError::EncodeError)
 }
 
 pub fn verify_access_token(
     access_token: &str,
-    tls_params: &TlsParams,
+    instance: &AuthlyInstance,
 ) -> Result<AuthlyAccessTokenClaims, AccessTokenError> {
     let validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::ES256);
     let token_data = jsonwebtoken::decode::<AuthlyAccessTokenClaims>(
         access_token,
-        &tls_params.jwt_decoding_key,
+        instance.local_jwt_decoding_key(),
         &validation,
     )
     .map_err(|err| AccessTokenError::Unverified(err.into()))?;
@@ -91,7 +89,7 @@ impl axum::extract::FromRequestParts<AuthlyCtx> for VerifiedAccessToken {
             .await
             .map_err(|_| (StatusCode::UNAUTHORIZED, "no access token"))?;
 
-        let claims = verify_access_token(authorization.token(), &ctx.tls_params)
+        let claims = verify_access_token(authorization.token(), &ctx.instance)
             .map_err(|_| (StatusCode::UNAUTHORIZED, "invalid access token"))?;
 
         Ok(Self { claims })

--- a/src/authority_mandate/submission/mandate.rs
+++ b/src/authority_mandate/submission/mandate.rs
@@ -3,13 +3,13 @@
 use authly_common::id::Eid;
 use rcgen::{CertificateParams, CertificateSigningRequest, DnType, KeyUsagePurpose};
 
-use crate::ctx::GetTlsParams;
+use crate::ctx::GetInstance;
 
 use super::SubmissionClaims;
 
 /// unverified decode of submission token, mandate side
 pub fn mandate_decode_submission_token(
-    deps: &impl GetTlsParams,
+    deps: &impl GetInstance,
     token: &str,
 ) -> anyhow::Result<SubmissionClaims> {
     let mut no_validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::ES256);
@@ -17,14 +17,14 @@ pub fn mandate_decode_submission_token(
 
     Ok(jsonwebtoken::decode(
         token,
-        &deps.get_tls_params().jwt_decoding_key,
+        deps.get_instance().local_jwt_decoding_key(),
         &no_validation,
     )?
     .claims)
 }
 
 pub fn mandate_identity_signing_request(
-    deps: &impl GetTlsParams,
+    deps: &impl GetInstance,
     mandate_eid: Eid,
 ) -> anyhow::Result<CertificateSigningRequest> {
     let common_name = mandate_eid.to_string();
@@ -49,5 +49,5 @@ pub fn mandate_identity_signing_request(
         params
     };
 
-    Ok(params.serialize_request(&deps.get_tls_params().local_ca.key)?)
+    Ok(params.serialize_request(deps.get_instance().private_key())?)
 }

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -1,22 +1,40 @@
+use std::ops::Deref;
+
 use pem::{EncodeConfig, Pem};
 use rcgen::{
     BasicConstraints, CertificateParams, DnType, DnValue, ExtendedKeyUsagePurpose, IsCa, KeyPair,
-    KeyUsagePurpose, PublicKeyData, SubjectPublicKeyInfo,
+    KeyUsagePurpose, PublicKeyData,
 };
 use rustls::pki_types::CertificateDer;
 use time::{Duration, OffsetDateTime};
 
-pub struct Cert<K> {
+pub struct Cert<'a, K> {
     pub params: CertificateParams,
     pub der: CertificateDer<'static>,
-    pub key: K,
+    pub key: Key<'a, K>,
 }
 
-impl Cert<KeyPair> {
-    pub fn sign<K: PublicKeyData>(&self, request: SigningRequest<K>) -> Cert<K> {
+pub enum Key<'a, K> {
+    Borrowed(&'a K),
+    Owned(K),
+}
+
+impl<K> Deref for Key<'_, K> {
+    type Target = K;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Borrowed(k) => k,
+            Self::Owned(k) => k,
+        }
+    }
+}
+
+impl Cert<'_, KeyPair> {
+    pub fn sign<'a, K: PublicKeyData>(&self, request: SigningRequest<'a, K>) -> Cert<'a, K> {
         let cert = request
             .params
-            .signed_by(&request.key, &self.params, &self.key)
+            .signed_by(request.key.deref(), &self.params, &self.key)
             .unwrap();
 
         Cert {
@@ -27,7 +45,7 @@ impl Cert<KeyPair> {
     }
 }
 
-impl<K> Cert<K> {
+impl<K> Cert<'_, K> {
     pub fn certificate_pem(&self) -> String {
         pem::encode_config(
             &Pem::new("CERTIFICATE", self.der.to_vec()),
@@ -36,19 +54,19 @@ impl<K> Cert<K> {
     }
 }
 
-impl Cert<KeyPair> {
+impl Cert<'_, KeyPair> {
     pub fn certificate_and_key_pem(&self) -> String {
         format!("{}{}", self.certificate_pem(), self.key.serialize_pem())
     }
 }
 
-pub struct SigningRequest<K> {
+pub struct SigningRequest<'a, K> {
     pub params: CertificateParams,
-    pub key: K,
+    pub key: Key<'a, K>,
 }
 
-impl SigningRequest<KeyPair> {
-    pub fn self_signed(self) -> Cert<KeyPair> {
+impl<'a> SigningRequest<'a, KeyPair> {
+    pub fn self_signed(self) -> Cert<'a, KeyPair> {
         let cert = self.params.self_signed(&self.key).unwrap();
 
         Cert {
@@ -59,91 +77,115 @@ impl SigningRequest<KeyPair> {
     }
 }
 
-pub trait MakeSigningRequest: Sized {
-    /// Create a new Authly CA with a very long expiry date
-    fn authly_ca(self) -> SigningRequest<Self> {
-        let mut params = CertificateParams::default();
-        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-        params
-            .distinguished_name
-            .push(DnType::CommonName, "Authly ID");
-        params
-            .distinguished_name
-            .push(DnType::OrganizationName, "Protojour AS");
-        params.distinguished_name.push(
-            DnType::CountryName,
-            DnValue::PrintableString("NO".try_into().unwrap()),
-        );
-        params.key_usages.push(KeyUsagePurpose::DigitalSignature);
-        params.key_usages.push(KeyUsagePurpose::KeyCertSign);
-        params.key_usages.push(KeyUsagePurpose::CrlSign);
+pub trait CertificateParamsExt {
+    fn with_owned_key<K>(self, key: K) -> SigningRequest<'static, K>;
+    fn with_borrowed_key<K>(self, key: &K) -> SigningRequest<'_, K>;
+    fn with_new_key_pair(self) -> SigningRequest<'static, KeyPair>;
+}
 
-        params.not_before = past(Duration::days(1));
-
-        SigningRequest { params, key: self }
+impl CertificateParamsExt for CertificateParams {
+    fn with_owned_key<K>(self, key: K) -> SigningRequest<'static, K> {
+        SigningRequest {
+            params: self,
+            key: Key::Owned(key),
+        }
     }
 
-    fn server_cert(self, common_name: &str, not_after: Duration) -> SigningRequest<Self> {
-        let mut params = CertificateParams::new(vec![common_name.to_string()])
-            .expect("we know the name is valid");
-        params
-            .distinguished_name
-            .push(DnType::CommonName, common_name);
-        params.use_authority_key_identifier_extension = true;
-        params.key_usages.push(KeyUsagePurpose::DigitalSignature);
-        params
-            .extended_key_usages
-            .push(ExtendedKeyUsagePurpose::ServerAuth);
-        params.not_before = past(Duration::days(1));
-        params.not_after = future(not_after);
-
-        SigningRequest { params, key: self }
+    fn with_borrowed_key<K>(self, key: &K) -> SigningRequest<'_, K> {
+        SigningRequest {
+            params: self,
+            key: Key::Borrowed(key),
+        }
     }
 
-    fn server_cert_csr(self, common_name: &str, not_after: Duration) -> SigningRequest<Self> {
-        let mut params = CertificateParams::new(vec![common_name.to_string()])
-            .expect("we know the name is valid");
-        params
-            .distinguished_name
-            .push(DnType::CommonName, common_name);
-        params.use_authority_key_identifier_extension = false;
-        params.key_usages.push(KeyUsagePurpose::DigitalSignature);
-        params
-            .extended_key_usages
-            .push(ExtendedKeyUsagePurpose::ServerAuth);
-        params.not_before = past(Duration::days(1));
-        params.not_after = future(not_after);
-
-        SigningRequest { params, key: self }
-    }
-
-    fn client_cert(self, common_name: &str, not_after: Duration) -> SigningRequest<Self> {
-        let mut params = CertificateParams::new(vec![]).expect("we know the name is valid");
-        params
-            .distinguished_name
-            .push(DnType::CommonName, common_name);
-        params.use_authority_key_identifier_extension = true;
-        params.key_usages.push(KeyUsagePurpose::DigitalSignature);
-        params
-            .extended_key_usages
-            .push(ExtendedKeyUsagePurpose::ClientAuth);
-        params.not_before = past(Duration::days(1));
-        params.not_after = future(not_after);
-
-        SigningRequest { params, key: self }
+    fn with_new_key_pair(self) -> SigningRequest<'static, KeyPair> {
+        SigningRequest {
+            params: self,
+            key: Key::Owned(key_pair()),
+        }
     }
 }
 
-impl MakeSigningRequest for KeyPair {}
-impl MakeSigningRequest for SubjectPublicKeyInfo {}
+/// Create a new Authly CA with a very long expiry date
+pub fn authly_ca() -> CertificateParams {
+    let mut params = CertificateParams::default();
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "Authly ID");
+    params
+        .distinguished_name
+        .push(DnType::OrganizationName, "Protojour AS");
+    params.distinguished_name.push(
+        DnType::CountryName,
+        DnValue::PrintableString("NO".try_into().unwrap()),
+    );
+    params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+    params.key_usages.push(KeyUsagePurpose::KeyCertSign);
+    params.key_usages.push(KeyUsagePurpose::CrlSign);
 
-impl<K> From<&Cert<K>> for reqwest::Certificate {
+    params.not_before = past(Duration::days(1));
+
+    params
+}
+
+pub fn server_cert(common_name: &str, not_after: Duration) -> CertificateParams {
+    let mut params =
+        CertificateParams::new(vec![common_name.to_string()]).expect("we know the name is valid");
+    params
+        .distinguished_name
+        .push(DnType::CommonName, common_name);
+    params.use_authority_key_identifier_extension = true;
+    params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+    params
+        .extended_key_usages
+        .push(ExtendedKeyUsagePurpose::ServerAuth);
+    params.not_before = past(Duration::days(1));
+    params.not_after = future(not_after);
+
+    params
+}
+
+pub fn server_cert_csr(common_name: &str, not_after: Duration) -> CertificateParams {
+    let mut params =
+        CertificateParams::new(vec![common_name.to_string()]).expect("we know the name is valid");
+    params
+        .distinguished_name
+        .push(DnType::CommonName, common_name);
+    params.use_authority_key_identifier_extension = false;
+    params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+    params
+        .extended_key_usages
+        .push(ExtendedKeyUsagePurpose::ServerAuth);
+    params.not_before = past(Duration::days(1));
+    params.not_after = future(not_after);
+
+    params
+}
+
+pub fn client_cert(common_name: &str, not_after: Duration) -> CertificateParams {
+    let mut params = CertificateParams::new(vec![]).expect("we know the name is valid");
+    params
+        .distinguished_name
+        .push(DnType::CommonName, common_name);
+    params.use_authority_key_identifier_extension = true;
+    params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+    params
+        .extended_key_usages
+        .push(ExtendedKeyUsagePurpose::ClientAuth);
+    params.not_before = past(Duration::days(1));
+    params.not_after = future(not_after);
+
+    params
+}
+
+impl<K> From<&Cert<'_, K>> for reqwest::Certificate {
     fn from(value: &Cert<K>) -> Self {
         reqwest::tls::Certificate::from_der(&value.der).unwrap()
     }
 }
 
-impl From<&Cert<KeyPair>> for reqwest::Identity {
+impl From<&Cert<'_, KeyPair>> for reqwest::Identity {
     fn from(value: &Cert<KeyPair>) -> Self {
         reqwest::Identity::from_pem(value.certificate_and_key_pem().as_bytes()).unwrap()
     }

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crate::{db::Db, AuthlyCtx, TlsParams};
+use crate::{db::Db, instance::AuthlyInstance, AuthlyCtx};
 
 pub trait GetDb {
     type Db: Db;
@@ -10,8 +10,8 @@ pub trait GetDb {
     fn get_db(&self) -> &Self::Db;
 }
 
-pub trait GetTlsParams {
-    fn get_tls_params(&self) -> &Arc<TlsParams>;
+pub trait GetInstance {
+    fn get_instance(&self) -> &Arc<AuthlyInstance>;
 }
 
 impl GetDb for AuthlyCtx {
@@ -22,8 +22,105 @@ impl GetDb for AuthlyCtx {
     }
 }
 
-impl GetTlsParams for AuthlyCtx {
-    fn get_tls_params(&self) -> &Arc<TlsParams> {
-        &self.tls_params
+impl GetInstance for AuthlyCtx {
+    fn get_instance(&self) -> &Arc<AuthlyInstance> {
+        &self.instance
+    }
+}
+
+pub mod test {
+    use std::sync::{Arc, RwLock};
+
+    use authly_common::id::Eid;
+
+    use crate::{
+        cert::{authly_ca, client_cert, key_pair},
+        instance::{AuthlyId, AuthlyInstance},
+        tls::{AuthlyCert, AuthlyCertKind},
+        Migrations,
+    };
+
+    use super::{GetDb, GetInstance};
+
+    #[derive(Default)]
+    pub struct TestCtx {
+        db: Option<RwLock<rusqlite::Connection>>,
+        instance: Option<Arc<AuthlyInstance>>,
+    }
+
+    impl TestCtx {
+        pub async fn inmemory_db(mut self) -> Self {
+            let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+            sqlite_migrate::<Migrations>(&mut conn).await;
+
+            self.db = Some(RwLock::new(conn));
+            self
+        }
+
+        pub fn supreme_instance(mut self) -> Self {
+            let authly_id = AuthlyId {
+                eid: Eid::random(),
+                private_key: key_pair(),
+            };
+            let certs = vec![
+                {
+                    let certificate = authly_ca().self_signed(&authly_id.private_key).unwrap();
+                    AuthlyCert {
+                        kind: AuthlyCertKind::Ca,
+                        certifies: authly_id.eid,
+                        signed_by: authly_id.eid,
+                        params: certificate.params().clone(),
+                        der: certificate.der().clone(),
+                    }
+                },
+                {
+                    let certificate =
+                        client_cert(&authly_id.eid.to_string(), time::Duration::days(365 * 100))
+                            .self_signed(&authly_id.private_key)
+                            .unwrap();
+                    AuthlyCert {
+                        kind: AuthlyCertKind::Identity,
+                        certifies: authly_id.eid,
+                        signed_by: authly_id.eid,
+                        params: certificate.params().clone(),
+                        der: certificate.der().clone(),
+                    }
+                },
+            ];
+
+            self.instance = Some(Arc::new(AuthlyInstance::new(authly_id, certs)));
+            self
+        }
+    }
+
+    impl GetDb for TestCtx {
+        type Db = RwLock<rusqlite::Connection>;
+
+        #[track_caller]
+        fn get_db(&self) -> &Self::Db {
+            self.db.as_ref().expect("TestCtx has no database")
+        }
+    }
+
+    impl GetInstance for TestCtx {
+        #[track_caller]
+        fn get_instance(&self) -> &Arc<AuthlyInstance> {
+            self.instance.as_ref().expect("TestCtx has no instance")
+        }
+    }
+
+    async fn sqlite_migrate<T: rust_embed::RustEmbed>(conn: &mut rusqlite::Connection) {
+        let mut files: Vec<_> = T::iter().collect();
+        files.sort();
+
+        let txn = conn.transaction().unwrap();
+
+        for file in files {
+            let migration = T::get(&file).unwrap();
+            txn.execute_batch(std::str::from_utf8(&migration.data).unwrap())
+                .unwrap();
+        }
+
+        txn.commit().unwrap();
     }
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -30,12 +30,10 @@ pub enum BuiltinID {
     /// The kubernetes service account name property.
     /// The value format is `{namespace}/{account_name}`.
     PropK8sServiceAccount = 11,
-    /// The local CA property
-    PropLocalCA = 12,
-    /// The local identity property
-    PropTlsIdentity = 13,
+    /// The Authly instance property
+    PropAuthlyInstance = 12,
     /// A user role for granting mandates to authority
-    AttrAuthlyRoleGrantMandate = 14,
+    AttrAuthlyRoleGrantMandate = 13,
 }
 
 impl BuiltinID {
@@ -65,8 +63,7 @@ impl BuiltinID {
             Self::PropPasswordHash => None,
             Self::PropLabel => None,
             Self::PropK8sServiceAccount => None,
-            Self::PropLocalCA => None,
-            Self::PropTlsIdentity => None,
+            Self::PropAuthlyInstance => None,
             Self::AttrAuthlyRoleGrantMandate => Some("grant_mandate"),
         }
     }
@@ -87,8 +84,7 @@ impl BuiltinID {
             Self::PropPasswordHash => true,
             Self::PropLabel => false,
             Self::PropK8sServiceAccount => true,
-            Self::PropLocalCA => true,
-            Self::PropTlsIdentity => true,
+            Self::PropAuthlyInstance => true,
         }
     }
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1,0 +1,106 @@
+use std::ops::Deref;
+
+use authly_common::id::Eid;
+use rcgen::{KeyPair, PublicKeyData};
+
+use crate::{
+    cert::{Cert, SigningRequest},
+    tls::{AuthlyCert, AuthlyCertKind},
+};
+
+/// Instance data, related to this installation of Authly
+pub struct AuthlyInstance {
+    authly_id: AuthlyId,
+    certs: Vec<AuthlyCert>,
+    local_jwt_decoding_key: jsonwebtoken::DecodingKey,
+}
+
+/// IDs of the authly instance.
+/// Consists of Entity ID and key pair.
+pub struct AuthlyId {
+    pub eid: Eid,
+    pub private_key: KeyPair,
+}
+
+impl AuthlyInstance {
+    pub fn new(id: AuthlyId, certs: Vec<AuthlyCert>) -> Self {
+        let _trust_root_ca = certs
+            .iter()
+            .find(|cert| {
+                matches!(cert.kind, AuthlyCertKind::Ca) && cert.certifies == cert.signed_by
+            })
+            .expect("trust root not provided");
+
+        let _trust_root_ca = certs
+            .iter()
+            .find(|cert| matches!(cert.kind, AuthlyCertKind::Identity) && cert.certifies == id.eid)
+            .expect("Self TLS identity not found");
+
+        let local_ca = certs
+            .iter()
+            .find(|cert| matches!(cert.kind, AuthlyCertKind::Ca) && cert.certifies == id.eid)
+            .expect("self CA not provided");
+
+        let local_jwt_decoding_key = {
+            let (_, x509_cert) = x509_parser::parse_x509_certificate(&local_ca.der).unwrap();
+
+            // Assume that EC is always used
+            jsonwebtoken::DecodingKey::from_ec_der(&x509_cert.public_key().subject_public_key.data)
+        };
+
+        Self {
+            authly_id: id,
+            certs,
+            local_jwt_decoding_key,
+        }
+    }
+
+    pub fn local_jwt_decoding_key(&self) -> &jsonwebtoken::DecodingKey {
+        &self.local_jwt_decoding_key
+    }
+
+    pub fn local_jwt_encoding_key(&self) -> jsonwebtoken::EncodingKey {
+        jsonwebtoken::EncodingKey::from_ec_der(self.private_key().serialized_der())
+    }
+
+    pub fn private_key(&self) -> &KeyPair {
+        &self.authly_id.private_key
+    }
+
+    pub fn trust_root_ca(&self) -> &AuthlyCert {
+        self.certs
+            .iter()
+            .find(|cert| {
+                matches!(cert.kind, AuthlyCertKind::Ca) && cert.certifies == cert.signed_by
+            })
+            .unwrap()
+    }
+
+    pub fn local_ca(&self) -> &AuthlyCert {
+        self.certs
+            .iter()
+            .find(|cert| {
+                matches!(cert.kind, AuthlyCertKind::Ca) && cert.certifies == self.authly_id.eid
+            })
+            .unwrap()
+    }
+
+    /// NB: local CA might be an intermediate cert
+    pub fn sign_with_local_ca<'a, K: PublicKeyData>(
+        &self,
+        request: SigningRequest<'a, K>,
+    ) -> Cert<'a, K> {
+        let local_ca = self.local_ca();
+
+        let certificate = request
+            .params
+            .signed_by(request.key.deref(), &local_ca.params, self.private_key())
+            .unwrap();
+
+        Cert {
+            params: certificate.params().clone(),
+            der: certificate.der().clone(),
+            key: request.key,
+        }
+    }
+}

--- a/src/k8s/k8s_manager.rs
+++ b/src/k8s/k8s_manager.rs
@@ -68,7 +68,7 @@ async fn write_client_configmap(client: Client, ctx: &AuthlyCtx) -> anyhow::Resu
         data: Some(
             [(
                 "ca.crt".to_string(),
-                ctx.tls_params.local_ca.certificate_pem(),
+                ctx.instance.trust_root_ca().certificate_pem(),
             )]
             .into(),
         ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,12 @@
 use std::env;
 
-use authly::{cert::MakeSigningRequest, configure, env_config::ClusterTlsPath, serve, EnvConfig};
+use authly::{
+    cert::{server_cert, CertificateParamsExt},
+    configure,
+    env_config::ClusterTlsPath,
+    serve, EnvConfig,
+};
 use clap::{Parser, Subcommand};
-use rcgen::KeyPair;
 use time::Duration;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
@@ -70,7 +74,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 fn issue_cluster_key(common_name: &str, tls_path: ClusterTlsPath) -> anyhow::Result<()> {
-    let req = KeyPair::generate()?.server_cert(common_name, Duration::days(10000));
+    let req = server_cert(common_name, Duration::days(10000)).with_new_key_pair();
     let certificate = req.params.self_signed(&req.key)?;
 
     std::fs::create_dir_all(&tls_path.0)?;

--- a/src/proto/mandate_submission.rs
+++ b/src/proto/mandate_submission.rs
@@ -42,7 +42,7 @@ impl AuthlyMandateSubmission for AuthlyMandateSubmissionServerImpl {
                 })?;
 
         Ok(tonic::Response::new(proto::SubmissionResponse {
-            authority_ca: self.ctx.tls_params.local_ca.der.to_vec(),
+            authority_ca: self.ctx.instance.local_ca().der.to_vec(),
             mandate_identity_cert_der: mandate_certificate.der().to_vec(),
         }))
     }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -35,7 +35,7 @@ pub(crate) fn main_service_grpc_router(ctx: AuthlyCtx) -> anyhow::Result<axum::R
                         .into_axum_router(),
                     tls_server_config: tls::generate_tls_server_config(
                         "authly-connect",
-                        &ctx.tls_params,
+                        &ctx.instance,
                         std::time::Duration::from_secs(365 * 100),
                     )?,
                 },

--- a/src/proto/service_server.rs
+++ b/src/proto/service_server.rs
@@ -84,7 +84,7 @@ impl AuthlyService for AuthlyServiceServerImpl {
                 let user_attrs = entity_db::list_entity_attrs(&self.ctx, session.eid).await?;
 
                 let token =
-                    access_token::create_access_token(&session, user_attrs, &self.ctx.tls_params)
+                    access_token::create_access_token(&session, user_attrs, &self.ctx.instance)
                         .map_err(|_| tonic::Status::internal("access token error"))?;
 
                 Result::<_, tonic::Status>::Ok(proto::AccessToken {
@@ -220,10 +220,11 @@ impl AuthlyService for AuthlyServiceServerImpl {
         // TODO: If a server certificate: Somehow verify that the peer service does not lie about its hostname/common name?
         // Authly would have to know its hostname in that case, if it's not the same as the service label.
 
-        let local_ca = &self.ctx.tls_params.local_ca;
-
         let certificate = csr_params
-            .signed_by(&local_ca.params, &local_ca.key)
+            .signed_by(
+                &self.ctx.instance.local_ca().params,
+                self.ctx.instance.private_key(),
+            )
             .map_err(|err| {
                 warn!(?err, "unable to sign service certificate");
                 tonic::Status::invalid_argument("Certificate signing problem")
@@ -308,7 +309,7 @@ fn verify_bearer(
         .and_then(|bearer| bearer.strip_prefix("Bearer "))
         .ok_or_else(|| tonic::Status::unauthenticated("invalid access token encoding"))?;
 
-    access_token::verify_access_token(token, &ctx.tls_params)
+    access_token::verify_access_token(token, &ctx.instance)
         .map_err(|_| tonic::Status::unauthenticated("access token not verified"))
 }
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,8 +1,8 @@
-use std::sync::{Arc, RwLock};
+use std::sync::RwLock;
 
 use authly::{
-    cert::{key_pair, Cert, MakeSigningRequest},
-    ctx::{GetDb, GetTlsParams},
+    cert::Cert,
+    ctx::{test::TestCtx, GetDb},
     db::{
         document_db,
         service_db::{self, ServicePropertyKind},
@@ -10,7 +10,6 @@ use authly::{
     },
     document::{compiled_document::DocumentMeta, doc_compiler::compile_doc},
     encryption::DecryptedDeks,
-    TlsParams,
 };
 use authly_common::{document::Document, id::Eid, service::PropertyMapping};
 use rcgen::KeyPair;
@@ -26,69 +25,6 @@ mod test_authly_connect;
 mod test_authority_mandate;
 mod test_document;
 mod test_tls;
-
-#[derive(Default)]
-struct TestCtx {
-    db: Option<RwLock<rusqlite::Connection>>,
-    identity: Option<Eid>,
-    tls_params: Option<Arc<TlsParams>>,
-}
-
-impl TestCtx {
-    pub async fn inmemory_db(mut self) -> Self {
-        use authly::Migrations;
-
-        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
-        sqlite_migrate::<Migrations>(&mut conn).await;
-
-        self.db = Some(RwLock::new(conn));
-        self
-    }
-
-    fn gen_tls_params(mut self) -> Self {
-        let ca = key_pair().authly_ca().self_signed();
-        let eid = Eid::random();
-        let identity = ca.sign(
-            KeyPair::generate()
-                .unwrap()
-                .client_cert(&eid.to_string(), time::Duration::hours(1)),
-        );
-        self.identity = Some(eid);
-        self.tls_params = Some(Arc::new(TlsParams::from_keys(ca, identity)));
-        self
-    }
-}
-
-impl GetDb for TestCtx {
-    type Db = RwLock<rusqlite::Connection>;
-
-    #[track_caller]
-    fn get_db(&self) -> &Self::Db {
-        self.db.as_ref().expect("TestCtx has no database")
-    }
-}
-
-impl GetTlsParams for TestCtx {
-    #[track_caller]
-    fn get_tls_params(&self) -> &Arc<TlsParams> {
-        self.tls_params.as_ref().expect("TestCtx has no TlsParams")
-    }
-}
-
-async fn sqlite_migrate<T: rust_embed::RustEmbed>(conn: &mut rusqlite::Connection) {
-    let mut files: Vec<_> = T::iter().collect();
-    files.sort();
-
-    let txn = conn.transaction().unwrap();
-
-    for file in files {
-        let migration = T::get(&file).unwrap();
-        txn.execute_batch(std::str::from_utf8(&migration.data).unwrap())
-            .unwrap();
-    }
-
-    txn.commit().unwrap();
-}
 
 async fn compile_and_apply_doc(
     doc: Document,

--- a/tests/integration/test_access_control.rs
+++ b/tests/integration/test_access_control.rs
@@ -1,4 +1,7 @@
-use authly::{ctx::GetDb, db::service_db};
+use authly::{
+    ctx::{test::TestCtx, GetDb},
+    db::service_db,
+};
 use authly_common::{
     document::Document,
     id::{AnyId, Eid},
@@ -7,7 +10,7 @@ use authly_common::{
 use hexhex::hex_literal;
 use indoc::indoc;
 
-use crate::{compile_and_apply_doc, ServiceProperties, TestCtx};
+use crate::{compile_and_apply_doc, ServiceProperties};
 
 const SVC_A: Eid = Eid::from_array(hex_literal!("e5462a0d22b54d9f9ca37bd96e9b9d8b"));
 const SVC_B: Eid = Eid::from_array(hex_literal!("015362d6655447c6b7f44865bd111c70"));

--- a/tests/integration/test_authly_connect.rs
+++ b/tests/integration/test_authly_connect.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use authly::cert::{key_pair, MakeSigningRequest};
+use authly::cert::{authly_ca, client_cert, server_cert, CertificateParamsExt};
 use authly_common::{
     mtls_server::PeerServiceEntity,
     proto::connect::{
@@ -18,7 +18,6 @@ use authly_test_grpc::{
 };
 use axum::{response::IntoResponse, Extension};
 use futures_util::{stream::BoxStream, StreamExt};
-use rcgen::KeyPair;
 use rustls::{pki_types::ServerName, RootCertStore, ServerConfig};
 use test_log::test;
 use time::Duration;
@@ -36,16 +35,11 @@ use crate::rustls_server_config_mtls;
 async fn test_connect_grpc() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let ca = key_pair().authly_ca().self_signed();
-    let tunneled_server_cert = ca.sign(
-        KeyPair::generate()
-            .unwrap()
-            .server_cert("authly-connect", Duration::hours(1)),
-    );
+    let ca = authly_ca().with_new_key_pair().self_signed();
+    let tunneled_server_cert =
+        ca.sign(server_cert("authly-connect", Duration::hours(1)).with_new_key_pair());
     let client_cert = ca.sign(
-        KeyPair::generate()
-            .unwrap()
-            .client_cert("cf2e74c3f26240908e1b4e8817bfde7c", Duration::hours(1)),
+        client_cert("cf2e74c3f26240908e1b4e8817bfde7c", Duration::hours(1)).with_new_key_pair(),
     );
     let cancel = CancellationToken::new();
 
@@ -156,16 +150,11 @@ impl authly_test_grpc::test_grpc_server::TestGrpc for TestGrpcServerImpl {
 async fn test_connect_http() {
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let ca = key_pair().authly_ca().self_signed();
-    let tunneled_server_cert = ca.sign(
-        KeyPair::generate()
-            .unwrap()
-            .server_cert("authly-connect", Duration::hours(1)),
-    );
+    let ca = authly_ca().with_new_key_pair().self_signed();
+    let tunneled_server_cert =
+        ca.sign(server_cert("authly-connect", Duration::hours(1)).with_new_key_pair());
     let client_cert = ca.sign(
-        KeyPair::generate()
-            .unwrap()
-            .client_cert("cf2e74c3f26240908e1b4e8817bfde7c", Duration::hours(1)),
+        client_cert("cf2e74c3f26240908e1b4e8817bfde7c", Duration::hours(1)).with_new_key_pair(),
     );
     let cancel = CancellationToken::new();
 

--- a/tests/integration/test_authority_mandate.rs
+++ b/tests/integration/test_authority_mandate.rs
@@ -17,8 +17,8 @@ use crate::TestCtx;
 
 #[test(tokio::test)]
 async fn test_mandate_registration_failure() {
-    let a_ctx = TestCtx::default().inmemory_db().await.gen_tls_params();
-    let m_ctx = TestCtx::default().inmemory_db().await.gen_tls_params();
+    let a_ctx = TestCtx::default().inmemory_db().await.supreme_instance();
+    let m_ctx = TestCtx::default().inmemory_db().await.supreme_instance();
 
     let token = authority_generate_submission_token(&a_ctx, b"INVALID CODE".to_vec())
         .await
@@ -38,11 +38,11 @@ async fn test_mandate_registration_failure() {
 
 #[test(tokio::test)]
 async fn test_mandate_registration() {
-    let a_ctx = TestCtx::default().inmemory_db().await.gen_tls_params();
-    // Two mandates:
+    let a_ctx = TestCtx::default().inmemory_db().await.supreme_instance();
+    // Two mandate wannabes:
     let m_ctxs = [
-        TestCtx::default().inmemory_db().await.gen_tls_params(),
-        TestCtx::default().inmemory_db().await.gen_tls_params(),
+        TestCtx::default().inmemory_db().await.supreme_instance(),
+        TestCtx::default().inmemory_db().await.supreme_instance(),
     ];
 
     let actor = Actor(Eid::random());


### PR DESCRIPTION
Removes a DB schema simplification. The app may now have many certificates, but only one private key. Some of the certs may be self-signed by that PK, and some may be upstream certs.