### PR TITLE
feat: AUTHLY_ID as key material for fundamental secrets

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+authly_id := "bf78d3c3bf94695c43b56540ffe23beace66ec53e35eee3f5be4c9a5cda70748"
+
 # setup docker dev environment
 dev-environment:
     docker-compose -f docker-compose.dev.yml up -d
@@ -7,11 +9,13 @@ generate-testdata:
     #!/usr/bin/env bash
     if ! test -d .local; then
         mkdir .local
+        AUTHLY_ID={{ authly_id }} \
         AUTHLY_ETC_DIR=.local/etc \
         AUTHLY_HOSTNAME=localhost \
         AUTHLY_K8S=true \
             cargo run -p authly --features dev issue-cluster-key
 
+        AUTHLY_ID={{ authly_id }} \
         AUTHLY_DOCUMENT_PATH="[examples/]" \
         AUTHLY_DATA_DIR=.local/data \
         AUTHLY_ETC_DIR=.local/etc \
@@ -23,6 +27,7 @@ debug_web_port := "12345"
 
 # run debug version on localhost. Necessary for running end-to-end tests.
 rundev: dev-environment generate-testdata
+    AUTHLY_ID={{ authly_id }} \
     AUTHLY_DOCUMENT_PATH="[examples/]" \
     AUTHLY_HOSTNAME=localhost \
     AUTHLY_SERVER_PORT=1443 \
@@ -33,6 +38,7 @@ rundev: dev-environment generate-testdata
 
 # run release version on localhost
 runrelease: dev-environment generate-testdata
+    AUTHLY_ID={{ authly_id }} \
     AUTHLY_DOCUMENT_PATH="[examples/]" \
     AUTHLY_HOSTNAME=localhost \
     AUTHLY_SERVER_PORT=1443 \

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use authly::{
     serve, EnvConfig,
 };
 use clap::{Parser, Subcommand};
+use rand::{rngs::OsRng, Rng};
 use time::Duration;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
@@ -24,6 +25,9 @@ struct Cli {
 enum Command {
     /// Run Authly in server/cluster mode
     Serve,
+
+    /// Generate a new unique AUTHLY_ID.
+    GenerateAuthlyId,
 
     /// Check if an Authly server is running at localhost
     Ready,
@@ -47,6 +51,12 @@ async fn main() -> anyhow::Result<()> {
 
     match Cli::parse().command {
         Some(Command::Serve) => serve().await?,
+        Some(Command::GenerateAuthlyId) => {
+            let mut id = [0u8; 32];
+            OsRng.fill(id.as_mut_slice());
+
+            println!("Generated Authly ID: {}", hexhex::hex(&id));
+        }
         Some(Command::Ready) => {
             reqwest::Client::new()
                 .get("http://localhost:5555/health/readiness")

--- a/src/util/serde.rs
+++ b/src/util/serde.rs
@@ -1,15 +1,16 @@
-use std::fmt;
+use std::fmt::{self, Display};
 
 use base64::{prelude::BASE64_URL_SAFE, Engine};
+use hex::{FromHex, ToHex};
 use serde::{de::Visitor, Deserialize, Serialize};
 
-#[derive(Clone, Serialize, Deserialize)]
-pub struct Hex(
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct Hex<T: FromHex<Error: Display> + ToHex + AsRef<[u8]> = Vec<u8>>(
     #[serde(
         serialize_with = "hex::serde::serialize",
         deserialize_with = "hex::serde::deserialize"
     )]
-    pub Vec<u8>,
+    pub T,
 );
 
 #[derive(Clone)]

--- a/testfiles/docker/docker-compose.yml
+++ b/testfiles/docker/docker-compose.yml
@@ -9,6 +9,7 @@ services:
   authly:
     image: protojour/authly:dev
     environment:
+      AUTHLY_ID: c865e85720e3c96feabdfe50c33acc75ac2069320de78d0d2c11497b092f1a8c
       AUTHLY_HOSTNAME: authly
       AUTHLY_K8S: 'false'
       AUTHLY_CLUSTER_API_SECRET: ifyougetholdofthisclassifiedpieceofinformationiwillunfortunatelyhavetokillyou

--- a/testfiles/k8s/authly.yaml
+++ b/testfiles/k8s/authly.yaml
@@ -38,6 +38,7 @@ metadata:
   namespace: authly-test
   name: authly-config
 data:
+  AUTHLY_ID: 05f06a77d9a06a7d31c43ad931f1f7669495363df30224f7b129b54f16c3b768
   AUTHLY_K8S: "true"
   AUTHLY_K8S_AUTH_HOSTNAME: authly-k8s
   AUTHLY_K8S_AUTH_SERVER_PORT: "2443"


### PR DESCRIPTION
Secrets should ideally be fetched from external systems instead of being env vars. There's a solution for that when the database is up, because it can store the master key "version".

But two secrets are needed before the database is even running: `AUTHLY_CLUSTER_API_SECRET` and `AUTHLY_CLUSTER_RAFT_SECRET`. Authly needs a way to identify those secrets, to avoid sharing secrets between several authly clusters using the same external secret storage system. The solution is `AUTHLY_ID`, which is used for deriving identifiers.