### PR TITLE
feat: add openbao support, use as standard for dev/example setups

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,9 +1,9 @@
 # This docker-compose file is used for local development.
 
 services:
-  authly-pal:
-    image: protojour/authly-pal:dev
+  openbao:
+    image: ghcr.io/openbao/openbao
     environment:
-      DANGER_ENCRYPTION_DISABLED: 'true'
+      BAO_DEV_ROOT_TOKEN_ID: theenigmaticbaobunofancientsecrets
     ports:
-      - 6666:6666
+      - 8200:8200

--- a/justfile
+++ b/justfile
@@ -13,6 +13,8 @@ generate-testdata:
         AUTHLY_ETC_DIR=.local/etc \
         AUTHLY_HOSTNAME=localhost \
         AUTHLY_K8S=true \
+        AUTHLY_BAO_TOKEN=theenigmaticbaobunofancientsecrets \
+        AUTHLY_BAO_URL=http://localhost:8200 \
             cargo run -p authly --features dev issue-cluster-key
 
         AUTHLY_ID={{ authly_id }} \
@@ -20,6 +22,8 @@ generate-testdata:
         AUTHLY_DATA_DIR=.local/data \
         AUTHLY_ETC_DIR=.local/etc \
         AUTHLY_EXPORT_TLS_TO_ETC=true \
+        AUTHLY_BAO_TOKEN=theenigmaticbaobunofancientsecrets \
+        AUTHLY_BAO_URL=http://localhost:8200 \
             cargo run -p authly --features dev configure
     fi
 
@@ -33,6 +37,8 @@ rundev: dev-environment generate-testdata
     AUTHLY_SERVER_PORT=1443 \
     AUTHLY_DATA_DIR=.local/data \
     AUTHLY_ETC_DIR=.local/etc \
+    AUTHLY_BAO_TOKEN=theenigmaticbaobunofancientsecrets \
+    AUTHLY_BAO_URL=http://localhost:8200 \
     AUTHLY_DEBUG_WEB_PORT={{ debug_web_port }} \
         cargo run -p authly --features dev serve
 
@@ -44,6 +50,8 @@ runrelease: dev-environment generate-testdata
     AUTHLY_SERVER_PORT=1443 \
     AUTHLY_DATA_DIR=.local/data \
     AUTHLY_ETC_DIR=.local/etc \
+    AUTHLY_BAO_TOKEN=theenigmaticbaobunofancientsecrets \
+    AUTHLY_BAO_URL=http://localhost:8200 \
         cargo run --release -p authly serve
 
 # clean up data files used for local run

--- a/src/env_config.rs
+++ b/src/env_config.rs
@@ -35,7 +35,9 @@ pub struct EnvConfig {
     /// Database directory
     pub data_dir: PathBuf,
 
-    pub pal_url: String,
+    pub pal_url: Option<String>,
+    pub bao_url: Option<String>,
+    pub bao_token: Option<String>,
 
     pub cluster_node_id: Option<u64>,
     pub cluster_api_nodes: Option<Vec<SocketAddr>>,
@@ -92,7 +94,9 @@ impl Default for EnvConfig {
             etc_dir: PathBuf::from("/etc/authly"),
             data_dir: PathBuf::from("/var/lib/authly/data"),
 
-            pal_url: "http://localhost:6666".to_string(),
+            pal_url: None,
+            bao_url: None,
+            bao_token: None,
 
             cluster_node_id: None,
             cluster_raft_nodes: None,

--- a/testfiles/docker/docker-compose.yml
+++ b/testfiles/docker/docker-compose.yml
@@ -1,21 +1,16 @@
 services:
-  # Authly Platform Abstraction Layer for secrets
-  authly-pal:
-    image: protojour/authly-pal:dev
-    environment:
-      DANGER_ENCRYPTION_DISABLED: 'true'
-
   # Authly itself
   authly:
     image: protojour/authly:dev
     environment:
       AUTHLY_ID: c865e85720e3c96feabdfe50c33acc75ac2069320de78d0d2c11497b092f1a8c
+      AUTHLY_BAO_TOKEN: theenigmaticbaobunofancientsecrets
+      AUTHLY_BAO_URL: http://openbao:8200
       AUTHLY_HOSTNAME: authly
       AUTHLY_K8S: 'false'
       AUTHLY_CLUSTER_API_SECRET: ifyougetholdofthisclassifiedpieceofinformationiwillunfortunatelyhavetokillyou
       AUTHLY_CLUSTER_RAFT_SECRET: donttellanybodyabouttheverysecretstring
       AUTHLY_EXPORT_TLS_TO_ETC: 'true'
-      AUTHLY_PAL_URL: http://authly-pal:6666
     ports:
       - 1443:443
     volumes:
@@ -30,12 +25,21 @@ services:
       retries: 10
       interval: 2s
     depends_on:
-      authly-pal:
+      openbao:
         condition: service_started
+
+  # Example supported secret store
+  openbao:
+    image: ghcr.io/openbao/openbao
+    environment:
+      BAO_DEV_ROOT_TOKEN_ID: theenigmaticbaobunofancientsecrets
+    command: server -dev
 
   # Example service for verifying connection
   testservice:
     image: protojour/authly-testservice:dev
+    ports:
+      - 2443:443
     volumes:
       - authly-certs:/etc/authly/certs:ro
       - testservice-identity:/etc/authly/identity:ro


### PR DESCRIPTION
This adds support for OpenBao, and sets it as the standard secret store for dev and Docker example setups, replacing authly-pal. Kubernetes example still uses Kubernetes secrets; should we standardize on OpenBao here too?

Having both OpenBao and authly-pal in `encryption.rs` is a bit messy, but this can be cleaned up later. Better to have this merged, or at least now, committed.