### PR TITLE
feat: mandatory namespacing/authly domains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "authly-client"
 version = "0.0.5"
-source = "git+https://github.com/protojour/authly-lib.git#22e61209b40639b966bee7742607594fdfc42dcd"
+source = "git+https://github.com/protojour/authly-lib.git?branch=authly-domain#7d7f6adcb04f214af2a4ad69c538b79453b211b1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "authly-common"
 version = "0.0.5"
-source = "git+https://github.com/protojour/authly-lib.git#22e61209b40639b966bee7742607594fdfc42dcd"
+source = "git+https://github.com/protojour/authly-lib.git?branch=authly-domain#7d7f6adcb04f214af2a4ad69c538b79453b211b1"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "authly-client"
 version = "0.0.5"
-source = "git+https://github.com/protojour/authly-lib.git?branch=authly-domain#7d7f6adcb04f214af2a4ad69c538b79453b211b1"
+source = "git+https://github.com/protojour/authly-lib.git?branch=authly-domain#166a4b106a1087aabb797271cffe27c68459ee16"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "authly-common"
 version = "0.0.5"
-source = "git+https://github.com/protojour/authly-lib.git?branch=authly-domain#7d7f6adcb04f214af2a4ad69c538b79453b211b1"
+source = "git+https://github.com/protojour/authly-lib.git?branch=authly-domain#166a4b106a1087aabb797271cffe27c68459ee16"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -463,6 +463,7 @@ dependencies = [
  "authly-common",
  "hexhex",
  "hiqlite",
+ "itertools 0.14.0",
  "rusqlite",
  "thiserror 2.0.11",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "authly-client"
 version = "0.0.5"
-source = "git+https://github.com/protojour/authly-lib.git?branch=authly-domain#166a4b106a1087aabb797271cffe27c68459ee16"
+source = "git+https://github.com/protojour/authly-lib.git?branch=authly-domain#24a9f39e46d07dbde41988c2a11af6f61933fb38"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "authly-common"
 version = "0.0.5"
-source = "git+https://github.com/protojour/authly-lib.git?branch=authly-domain#166a4b106a1087aabb797271cffe27c68459ee16"
+source = "git+https://github.com/protojour/authly-lib.git?branch=authly-domain#24a9f39e46d07dbde41988c2a11af6f61933fb38"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "authly-client"
 version = "0.0.5"
-source = "git+https://github.com/protojour/authly-lib.git?branch=authly-domain#24a9f39e46d07dbde41988c2a11af6f61933fb38"
+source = "git+https://github.com/protojour/authly-lib.git#571219bfdc16820563bc66144bea84fd9dd3e632"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "authly-common"
 version = "0.0.5"
-source = "git+https://github.com/protojour/authly-lib.git?branch=authly-domain#24a9f39e46d07dbde41988c2a11af6f61933fb38"
+source = "git+https://github.com/protojour/authly-lib.git#571219bfdc16820563bc66144bea84fd9dd3e632"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,8 +132,8 @@ rust-version = "1.83"
 publish = false
 
 [workspace.dependencies]
-authly-common = { git = "https://github.com/protojour/authly-lib.git", branch = "authly-domain" }
-authly-client = { git = "https://github.com/protojour/authly-lib.git", branch = "authly-domain" }
+authly-common = { git = "https://github.com/protojour/authly-lib.git" }
+authly-client = { git = "https://github.com/protojour/authly-lib.git" }
 hiqlite = { version = "0.5", default-features = false, features = [
     "auto-heal",
     "listen_notify_local",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,8 +132,8 @@ rust-version = "1.83"
 publish = false
 
 [workspace.dependencies]
-authly-common = { git = "https://github.com/protojour/authly-lib.git" }
-authly-client = { git = "https://github.com/protojour/authly-lib.git" }
+authly-common = { git = "https://github.com/protojour/authly-lib.git", branch = "authly-domain" }
+authly-client = { git = "https://github.com/protojour/authly-lib.git", branch = "authly-domain" }
 hiqlite = { version = "0.5", default-features = false, features = [
     "auto-heal",
     "listen_notify_local",

--- a/examples/0_rudiments.toml
+++ b/examples/0_rudiments.toml
@@ -11,5 +11,5 @@ SERVER_CERT_ROTATION_RATE = "3m"
 [[service-entity]]
 eid = "3c2f40b3f47a4d9b9129b1e7c15fbc04"
 label = "arx"
-attributes = ["authly:role/authenticate", "authly:role/get_access_token"]
+attributes = ["authly:role:authenticate", "authly:role:get_access_token"]
 kubernetes-account = { name = "arx", namespace = "authly-test" }

--- a/examples/2_testservice.toml
+++ b/examples/2_testservice.toml
@@ -4,21 +4,21 @@ id = "bc9ce588-50c3-47d1-94c1-f88b21eaf299"
 [[service-entity]]
 eid = "f3e799137c034e1eb4cd3e4f65705932"
 label = "testservice"
-attributes = ["authly:role/authenticate", "authly:role/get_access_token"]
+attributes = ["authly:role:authenticate", "authly:role:get_access_token"]
 kubernetes-account = { name = "testservice", namespace = "authly-test" }
 
 [[entity-property]]
 service = "testservice"
 label = "role"
-attributes = ["ui:user", "ui:admin"]
+attributes = ["ui/user", "ui/admin"]
 
 [[entity-attribute-binding]]
 eid = "0fbcd73e1a884424a1615c3c3fdeebec"
-attributes = ["role/ui:user"]
+attributes = ["testservice:role:ui/user"]
 
 [[entity-attribute-binding]]
 eid = "96bf83f88cbf455fa356553f7fca1b9e"
-attributes = ["role/ui:admin"]
+attributes = ["testservice:role:ui/admin"]
 
 [[resource-property]]
 service = "testservice"
@@ -27,45 +27,45 @@ attributes = ["ontology", "storage"]
 
 [[resource-property]]
 service = "testservice"
-label = "ontology:action"
+label = "ontology/action"
 attributes = ["read", "deploy", "stop"]
 
 [[resource-property]]
 service = "testservice"
-label = "buckets:action"
+label = "buckets/action"
 attributes = ["read"]
 
 [[resource-property]]
 service = "testservice"
-label = "bucket:action"
+label = "bucket/action"
 attributes = ["read", "create", "delete"]
 
 [[resource-property]]
 service = "testservice"
-label = "object:action"
+label = "object/action"
 attributes = ["read", "create", "delete"]
 
 [[policy]]
 service = "testservice"
 label = "allow for main service"
-allow = "Subject.entity == testservice"
+allow = "Subject.authly:entity == testservice"
 
 [[policy]]
 service = "testservice"
 label = "allow for UI user"
-allow = "Subject.role contains role/ui:user"
+allow = "Subject.testservice:role contains testservice:role:ui/user"
 
 [[policy]]
 service = "testservice"
 label = "allow for UI admin"
-allow = "Subject.role contains role/ui:admin"
+allow = "Subject.testservice:role contains testservice:role:ui/admin"
 
 [[policy-binding]]
 service = "testservice"
-attributes = ["ontology:action/read"]
+attributes = ["testservice:ontology/action:read"]
 policies = ["allow for main service", "allow for UI user"]
 
 [[policy-binding]]
 service = "testservice"
-attributes = ["ontology:action/deploy"]
+attributes = ["testservice:ontology/action:deploy"]
 policies = ["allow for main service", "allow for UI admin"]

--- a/examples/2_testservice.toml
+++ b/examples/2_testservice.toml
@@ -8,7 +8,7 @@ attributes = ["authly:role:authenticate", "authly:role:get_access_token"]
 kubernetes-account = { name = "testservice", namespace = "authly-test" }
 
 [[entity-property]]
-service = "testservice"
+domain = "testservice"
 label = "role"
 attributes = ["ui/user", "ui/admin"]
 
@@ -21,51 +21,46 @@ eid = "96bf83f88cbf455fa356553f7fca1b9e"
 attributes = ["testservice:role:ui/admin"]
 
 [[resource-property]]
-service = "testservice"
+domain = "testservice"
 label = "name"
 attributes = ["ontology", "storage"]
 
 [[resource-property]]
-service = "testservice"
+domain = "testservice"
 label = "ontology/action"
 attributes = ["read", "deploy", "stop"]
 
 [[resource-property]]
-service = "testservice"
+domain = "testservice"
 label = "buckets/action"
 attributes = ["read"]
 
 [[resource-property]]
-service = "testservice"
+domain = "testservice"
 label = "bucket/action"
 attributes = ["read", "create", "delete"]
 
 [[resource-property]]
-service = "testservice"
+domain = "testservice"
 label = "object/action"
 attributes = ["read", "create", "delete"]
 
 [[policy]]
-service = "testservice"
 label = "allow for main service"
 allow = "Subject.authly:entity == testservice"
 
 [[policy]]
-service = "testservice"
 label = "allow for UI user"
 allow = "Subject.testservice:role contains testservice:role:ui/user"
 
 [[policy]]
-service = "testservice"
 label = "allow for UI admin"
 allow = "Subject.testservice:role contains testservice:role:ui/admin"
 
 [[policy-binding]]
-service = "testservice"
 attributes = ["testservice:ontology/action:read"]
 policies = ["allow for main service", "allow for UI user"]
 
 [[policy-binding]]
-service = "testservice"
 attributes = ["testservice:ontology/action:deploy"]
 policies = ["allow for main service", "allow for UI admin"]

--- a/grammar/policy.pest
+++ b/grammar/policy.pest
@@ -20,8 +20,8 @@ unary_not = { "not" }
 
 // terms
 term = _{ term_field | term_attr | label }
-term_field = { global ~ "." ~ label }
-term_attr = { label ~ "/" ~ label }
+term_field = { global ~ "." ~ label ~ ":" ~ label }
+term_attr = { label ~ ":" ~ label ~ ":" ~ label }
 
 // Global symbols start with with uppercase
 global = @{ "Subject" | "Resource" }
@@ -31,7 +31,7 @@ global = @{ "Subject" | "Resource" }
 label = @{ ASCII_ALPHA_LOWER ~ label_infix_char* }
 
 // Valid characters in a symbol
-label_infix_char = { ASCII_ALPHANUMERIC | "_" | ":" }
+label_infix_char = { ASCII_ALPHANUMERIC | "_" | "/" }
 
 // Special whitespace rule
 WHITESPACE = _{ " " }

--- a/lib/authly-db/Cargo.toml
+++ b/lib/authly-db/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 [dependencies]
 authly-common.workspace = true
 hexhex = "1"
+itertools = "0.14"
 hiqlite.workspace = true
 rusqlite = "0.33"
 thiserror = "2"

--- a/lib/authly-db/src/sqlite.rs
+++ b/lib/authly-db/src/sqlite.rs
@@ -112,7 +112,7 @@ impl RusqliteRow {
 
         for (idx, col) in columns.iter().enumerate() {
             let val = match &col.ty {
-                RusqliteColumnType::Expr => todo!("expr"),
+                RusqliteColumnType::Expr => row.get(idx).unwrap_or(Value::Null),
                 RusqliteColumnType::Integer => {
                     row.get(idx).map(Value::Integer).unwrap_or(Value::Null)
                 }

--- a/migrations/1_init.sql
+++ b/migrations/1_init.sql
@@ -31,14 +31,14 @@ CREATE TABLE tls_cert (
 
 -- Any kind of directory, including other Authly Authorities
 CREATE TABLE directory (
-    did BLOB NOT NULL PRIMARY KEY,
+    dir_id BLOB NOT NULL PRIMARY KEY,
     kind TEXT NOT NULL,
     url TEXT,
     hash BLOB
 );
 
 CREATE TABLE local_setting (
-    did BLOB NOT NULL,
+    dir_id BLOB NOT NULL,
     setting INTEGER NOT NULL,
     value TEXT NOT NULL
 );
@@ -50,7 +50,7 @@ CREATE TABLE session (
 );
 
 CREATE TABLE ent_attr (
-    did BLOB NOT NULL,
+    dir_id BLOB NOT NULL,
     eid BLOB NOT NULL,
     attrid BLOB NOT NULL,
 
@@ -58,7 +58,7 @@ CREATE TABLE ent_attr (
 );
 
 CREATE TABLE ent_text_attr (
-    did BLOB NOT NULL,
+    dir_id BLOB NOT NULL,
     eid BLOB NOT NULL,
     prop_id BLOB NOT NULL,
     value TEXT NOT NULL,
@@ -67,7 +67,7 @@ CREATE TABLE ent_text_attr (
 );
 
 CREATE TABLE ent_ident (
-    did BLOB NOT NULL,
+    dir_id BLOB NOT NULL,
     eid BLOB NOT NULL,
     prop_id BLOB NOT NULL,
     fingerprint BLOB NOT NULL,
@@ -79,7 +79,7 @@ CREATE TABLE ent_ident (
 );
 
 CREATE TABLE ent_rel (
-    did BLOB NOT NULL,
+    dir_id BLOB NOT NULL,
     rel_id BLOB NOT NULL,
     subject_eid BLOB NOT NULL,
     object_eid BLOB NOT NULL,
@@ -87,17 +87,26 @@ CREATE TABLE ent_rel (
     PRIMARY KEY (rel_id, subject_eid, object_eid)
 );
 
-CREATE TABLE svc_ent_prop (
-    did BLOB NOT NULL,
+-- Domain: Property namespaces (not entities)
+CREATE TABLE domain (
+    dir_id BLOB NOT NULL,
     id BLOB NOT NULL PRIMARY KEY,
-    svc_eid BLOB NOT NULL,
-    label TEXT NOT NULL,
-
-    UNIQUE (svc_eid, label)
+    label TEXT NOT NULL
 );
 
-CREATE TABLE svc_ent_attrlabel (
-    did BLOB NOT NULL,
+-- Domain: entity property
+CREATE TABLE dom_ent_prop (
+    dir_id BLOB NOT NULL,
+    id BLOB NOT NULL PRIMARY KEY,
+    dom_id BLOB NOT NULL,
+    label TEXT NOT NULL,
+
+    UNIQUE (dom_id, label)
+);
+
+-- Domain: entity property attribute label
+CREATE TABLE dom_ent_attrlabel (
+    dir_id BLOB NOT NULL,
     id BLOB NOT NULL,
     prop_id BLOB NOT NULL,
     label TEXT NOT NULL,
@@ -105,17 +114,19 @@ CREATE TABLE svc_ent_attrlabel (
     UNIQUE (prop_id, label)
 );
 
-CREATE TABLE svc_res_prop (
-    did BLOB NOT NULL,
+-- Domain: resource property
+CREATE TABLE dom_res_prop (
+    dir_id BLOB NOT NULL,
     id BLOB NOT NULL PRIMARY KEY,
-    svc_eid BLOB NOT NULL,
+    dom_id BLOB NOT NULL,
     label TEXT NOT NULL,
 
-    UNIQUE (svc_eid, label)
+    UNIQUE (dom_id, label)
 );
 
-CREATE TABLE svc_res_attrlabel (
-    did BLOB NOT NULL,
+-- Domain: resource attribute label
+CREATE TABLE dom_res_attrlabel (
+    dir_id BLOB NOT NULL,
     id BLOB NOT NULL PRIMARY KEY,
     prop_id BLOB NOT NULL,
     label TEXT NOT NULL,
@@ -123,21 +134,41 @@ CREATE TABLE svc_res_attrlabel (
     UNIQUE (prop_id, label)
 );
 
-CREATE TABLE svc_policy (
-    did BLOB NOT NULL,
-    id BLOB NOT NULL PRIMARY KEY,
+-- Service: domain participation
+CREATE TABLE svc_domain (
+    dir_id BLOB NOT NULL,
     svc_eid BLOB NOT NULL,
+    dom_id BLOB NOT NULL,
+
+    PRIMARY KEY (svc_eid, dom_id)
+);
+
+-- TODO: Should policies be associated to domains (as a namespace)?
+CREATE TABLE policy (
+    dir_id BLOB NOT NULL,
+    id BLOB NOT NULL PRIMARY KEY,
     label TEXT NOT NULL,
     policy_pc BLOB NOT NULL,
 
-    UNIQUE (svc_eid, label)
+    UNIQUE (label)
 );
 
-CREATE TABLE svc_policy_binding (
-    did BLOB NOT NULL,
-    svc_eid BLOB NOT NULL,
-    attr_matcher_pc BLOB NOT NULL,
-    policy_ids_pc BLOB NOT NULL
+-- Policy binding - attribute matchers
+CREATE TABLE polbind_attr_match (
+    dir_id BLOB NOT NULL,
+    polbind_id BLOB NOT NULL,
+    attr_id BLOB NOT NULL,
+
+    PRIMARY KEY (polbind_id, attr_id)
+);
+
+-- Policy binding - policy implication
+CREATE TABLE polbind_policy (
+    dir_id BLOB NOT NULL,
+    polbind_id BLOB NOT NULL,
+    policy_id BLOB NOT NULL,
+
+    PRIMARY KEY (polbind_id, policy_id)
 );
 
 -- This table has one entry if Authly is trying to become a mandate of an authority

--- a/migrations/1_init.sql
+++ b/migrations/1_init.sql
@@ -57,15 +57,6 @@ CREATE TABLE ent_attr (
     PRIMARY KEY (eid, attrid)
 );
 
-CREATE TABLE ent_text_attr (
-    dir_id BLOB NOT NULL,
-    eid BLOB NOT NULL,
-    prop_id BLOB NOT NULL,
-    value TEXT NOT NULL,
-
-    PRIMARY KEY (eid, prop_id)
-);
-
 CREATE TABLE ent_ident (
     dir_id BLOB NOT NULL,
     eid BLOB NOT NULL,
@@ -87,7 +78,17 @@ CREATE TABLE ent_rel (
     PRIMARY KEY (rel_id, subject_eid, object_eid)
 );
 
+CREATE TABLE obj_text_attr (
+    dir_id BLOB NOT NULL,
+    obj_id BLOB NOT NULL,
+    prop_id BLOB NOT NULL,
+    value TEXT NOT NULL,
+
+    PRIMARY KEY (obj_id, prop_id)
+);
+
 -- Domain: Property namespaces (not entities)
+-- TODO: This table is not needed (obj_text_attr will be enough when ID can tag the underlying type)
 CREATE TABLE domain (
     dir_id BLOB NOT NULL,
     id BLOB NOT NULL PRIMARY KEY,

--- a/src/bus/handler.rs
+++ b/src/bus/handler.rs
@@ -32,8 +32,8 @@ pub async fn authly_node_handle_incoming_message(
             ))
             .await?;
         }
-        ClusterMessage::DirectoryChanged { did } => {
-            info!(?did, "directory changed");
+        ClusterMessage::DirectoryChanged { dir_id } => {
+            info!(?dir_id, "directory changed");
         }
         ClusterMessage::ClientBroadcast(client_message) => {
             info!(?client_message, "TODO: client broadcast");

--- a/src/bus/message.rs
+++ b/src/bus/message.rs
@@ -1,4 +1,4 @@
-use authly_common::id::Eid;
+use authly_common::id::ObjId;
 use serde::{Deserialize, Serialize};
 
 /// Message type used by the Authly message bus (hiqlite notify mechanism).
@@ -17,7 +17,7 @@ pub enum ClusterMessage {
     /// It can also mean the directory was added or removed.
     DirectoryChanged {
         /// The directory ID that changed
-        did: Eid,
+        dir_id: ObjId,
     },
 
     /// Broadcast message to all connected clients

--- a/src/db/directory_db.rs
+++ b/src/db/directory_db.rs
@@ -1,0 +1,117 @@
+//! directory-oriented queries
+
+use std::collections::HashMap;
+
+use authly_common::id::{AnyId, ObjId};
+use authly_db::{param::AsParam, Db, DbError, DbResult, Row};
+use hiqlite::{params, Param};
+use indoc::indoc;
+
+use super::{
+    policy_db::DbPolicy,
+    service_db::{ServiceProperty, ServicePropertyKind},
+    Identified,
+};
+
+pub async fn directory_list_domains(
+    deps: &impl Db,
+    dir_id: ObjId,
+) -> DbResult<Vec<Identified<ObjId, String>>> {
+    Ok(deps
+        .query_raw(
+            "SELECT id, label FROM domain WHERE dir_id = $1".into(),
+            params!(dir_id.as_param()),
+        )
+        .await?
+        .into_iter()
+        .map(|mut row| Identified(row.get_id("id"), row.get_text("label")))
+        .collect())
+}
+
+pub async fn directory_list_policies(
+    deps: &impl Db,
+    dir_id: ObjId,
+) -> DbResult<Vec<Identified<ObjId, DbPolicy>>> {
+    let rows = deps
+        .query_raw(
+            "SELECT id, label, policy_pc FROM policy WHERE dir_id = $1".into(),
+            params!(dir_id.as_param()),
+        )
+        .await?;
+
+    let mut policies = Vec::with_capacity(rows.len());
+
+    for mut row in rows {
+        let id = row.get_id("id");
+        let label = row.get_text("label");
+
+        let policy = postcard::from_bytes(&row.get_blob("policy_pc")).map_err(|err| {
+            tracing::error!(?err, "policy expr postcard error");
+            DbError::BinaryEncoding
+        })?;
+
+        policies.push(Identified(id, DbPolicy { label, policy }));
+    }
+
+    Ok(policies)
+}
+
+pub async fn list_domain_properties(
+    deps: &impl Db,
+    dir_id: ObjId,
+    dom_id: AnyId,
+    property_kind: ServicePropertyKind,
+) -> DbResult<Vec<ServiceProperty>> {
+    let rows = match property_kind {
+        ServicePropertyKind::Entity => {
+            deps.query_raw(
+                indoc! {
+                    "
+                    SELECT p.id pid, p.label plabel, a.id attrid, a.label alabel
+                    FROM dom_ent_prop p
+                    JOIN dom_ent_attrlabel a ON a.prop_id = p.id
+                    WHERE p.dir_id = $1 AND p.dom_id = $2
+                    ",
+                }
+                .into(),
+                params!(dir_id.as_param(), dom_id.as_param()),
+            )
+            .await?
+        }
+        ServicePropertyKind::Resource => {
+            deps.query_raw(
+                indoc! {
+                    "
+                    SELECT p.id pid, p.label plabel, a.id attrid, a.label alabel
+                    FROM dom_res_prop p
+                    JOIN dom_res_attrlabel a ON a.prop_id = p.id
+                    WHERE p.dir_id = $1 AND p.dom_id = $2
+                    ",
+                }
+                .into(),
+                params!(dir_id.as_param(), dom_id.as_param()),
+            )
+            .await?
+        }
+    };
+
+    let mut properties: HashMap<ObjId, ServiceProperty> = Default::default();
+
+    for mut row in rows {
+        let prop_id = row.get_id("pid");
+
+        let property = properties
+            .entry(prop_id)
+            .or_insert_with(|| ServiceProperty {
+                id: prop_id,
+                label: row.get_text("plabel"),
+                attributes: vec![],
+            });
+
+        property
+            .attributes
+            .push((row.get_id("attrid"), row.get_text("alabel")));
+    }
+
+    Ok(properties.into_values().collect())
+}

--- a/src/db/document_db.rs
+++ b/src/db/document_db.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use aes_gcm_siv::aead::Aead;
-use authly_common::id::Eid;
+use authly_common::id::ObjId;
 use authly_db::{literal::Literal, param::AsParam, Db, DbResult, Row};
 use hiqlite::{params, Param, Params};
 use indoc::indoc;
@@ -13,8 +13,11 @@ use crate::{
     encryption::{random_nonce, DecryptedDeks},
 };
 
+use super::Identified;
+
+/// An Authly directory backed by a document
 pub struct DocumentDirectory {
-    pub did: Eid,
+    pub dir_id: ObjId,
     pub url: String,
     pub hash: [u8; 32],
 }
@@ -22,13 +25,13 @@ pub struct DocumentDirectory {
 pub async fn get_documents(deps: &impl Db) -> DbResult<Vec<DocumentDirectory>> {
     Ok(deps
         .query_raw(
-            "SELECT did, url, hash FROM directory WHERE kind = 'document'".into(),
+            "SELECT dir_id, url, hash FROM directory WHERE kind = 'document'".into(),
             params!(),
         )
         .await?
         .into_iter()
         .map(|mut row| DocumentDirectory {
-            did: row.get_id("did"),
+            dir_id: row.get_id("dir_id"),
             url: row.get_text("url"),
             hash: {
                 row.get_blob("hash")
@@ -44,25 +47,25 @@ pub fn document_txn_statements(
     document: CompiledDocument,
     deks: &DecryptedDeks,
 ) -> anyhow::Result<Vec<(Cow<'static, str>, Params)>> {
-    let CompiledDocument { did, meta, data } = document;
+    let CompiledDocument { dir_id, meta, data } = document;
     let mut stmts: Vec<(Cow<'static, str>, Params)> = vec![];
 
     stmts.push((
-        "INSERT INTO directory (did, kind, url, hash) VALUES ($1, 'document', $2, $3) ON CONFLICT DO UPDATE SET url = $2, hash = $3".into(),
-        params!(did.as_param(), meta.url, meta.hash.to_vec()),
+        "INSERT INTO directory (dir_id, kind, url, hash) VALUES ($1, 'document', $2, $3) ON CONFLICT DO UPDATE SET url = $2, hash = $3".into(),
+        params!(dir_id.as_param(), meta.url, meta.hash.to_vec()),
     ));
 
     // local settings
     {
         stmts.push((
-            "DELETE FROM local_setting WHERE did = $1".into(),
-            params!(did.as_param()),
+            "DELETE FROM local_setting WHERE dir_id = $1".into(),
+            params!(dir_id.as_param()),
         ));
 
         for (setting, value) in data.settings {
             stmts.push((
-                "INSERT INTO local_setting (did, setting, value) VALUES ($1, $2, $3)".into(),
-                params!(did.as_param(), setting as i64, value),
+                "INSERT INTO local_setting (dir_id, setting, value) VALUES ($1, $2, $3)".into(),
+                params!(dir_id.as_param(), setting as i64, value),
             ));
         }
     }
@@ -71,8 +74,8 @@ pub fn document_txn_statements(
     {
         // not sure how to "GC" this?
         stmts.push((
-            "DELETE FROM ent_ident WHERE did = $1".into(),
-            params!(did.as_param()),
+            "DELETE FROM ent_ident WHERE dir_id = $1".into(),
+            params!(dir_id.as_param()),
         ));
 
         for ident in data.entity_ident {
@@ -83,9 +86,9 @@ pub fn document_txn_statements(
             let ciph = dek.aes().encrypt(&nonce, ident.ident.as_bytes())?;
 
             stmts.push((
-                "INSERT INTO ent_ident (did, eid, prop_id, fingerprint, nonce, ciph) VALUES ($1, $2, $3, $4, $5, $6)".into(),
+                "INSERT INTO ent_ident (dir_id, eid, prop_id, fingerprint, nonce, ciph) VALUES ($1, $2, $3, $4, $5, $6)".into(),
                 params!(
-                    did.as_param(),
+                    dir_id.as_param(),
                     ident.eid.as_param(),
                     ident.prop_id.as_param(),
                     fingerprint.to_vec(),
@@ -97,14 +100,14 @@ pub fn document_txn_statements(
 
         // not sure how to "GC" this?
         stmts.push((
-            "DELETE FROM ent_text_attr WHERE did = $1".into(),
-            params!(did.as_param()),
+            "DELETE FROM ent_text_attr WHERE dir_id = $1".into(),
+            params!(dir_id.as_param()),
         ));
 
         for text_prop in data.entity_text_attrs {
             stmts.push((
-                "INSERT INTO ent_text_attr (did, eid, prop_id, value) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING".into(),
-                params!(did.as_param(), text_prop.eid.as_param(), text_prop.prop_id.as_param(), text_prop.value),
+                "INSERT INTO ent_text_attr (dir_id, eid, prop_id, value) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING".into(),
+                params!(dir_id.as_param(), text_prop.eid.as_param(), text_prop.prop_id.as_param(), text_prop.value),
             ));
         }
     }
@@ -113,16 +116,16 @@ pub fn document_txn_statements(
     {
         // not sure how to "GC" this?
         stmts.push((
-            "DELETE FROM ent_rel WHERE did = $1".into(),
-            params!(did.as_param()),
+            "DELETE FROM ent_rel WHERE dir_id = $1".into(),
+            params!(dir_id.as_param()),
         ));
 
         for rel in data.entity_relations {
             stmts.push((
-                "INSERT INTO ent_rel (did, subject_eid, rel_id, object_eid) VALUES ($1, $2, $3, $4)"
+                "INSERT INTO ent_rel (dir_id, subject_eid, rel_id, object_eid) VALUES ($1, $2, $3, $4)"
                     .into(),
                 params!(
-                    did.as_param(),
+                    dir_id.as_param(),
                     rel.subject.as_param(),
                     rel.relation.as_param(),
                     rel.object.as_param()
@@ -131,18 +134,58 @@ pub fn document_txn_statements(
         }
     }
 
+    // domain
+    {
+        stmts.push(gc(
+            "domain",
+            NotIn("id", data.domains.iter().map(|i| *i.id())),
+            dir_id,
+        ));
+
+        for Identified(id, label) in data.domains {
+            stmts.push((
+                "INSERT INTO domain (dir_id, id, label) VALUES ($1, $2, $3) ON CONFLICT DO UPDATE SET label = $3".into(),
+                params!(dir_id.as_param(), id.as_param(), label),
+            ));
+        }
+    }
+
+    // service - domain
+    {
+        // not sure how to "GC" this?
+        stmts.push((
+            "DELETE FROM svc_domain WHERE dir_id = $1".into(),
+            params!(dir_id.as_param()),
+        ));
+
+        for svc_id in data.service_ids {
+            // the service is in its own domain
+            stmts.push((
+                "INSERT INTO svc_domain (dir_id, svc_eid, dom_id) VALUES ($1, $2, $3)".into(),
+                params!(dir_id.as_param(), svc_id.as_param(), svc_id.as_param()),
+            ));
+        }
+
+        for (svc_id, dom_id) in data.service_domains {
+            stmts.push((
+                "INSERT INTO svc_domain (dir_id, svc_eid, dom_id) VALUES ($1, $2, $3)".into(),
+                params!(dir_id.as_param(), svc_id.as_param(), dom_id.as_param()),
+            ));
+        }
+    }
+
     // service attribute assignment
     {
         // not sure how to "GC" this?
         stmts.push((
-            "DELETE FROM ent_attr WHERE did = $1".into(),
-            params!(did.as_param()),
+            "DELETE FROM ent_attr WHERE dir_id = $1".into(),
+            params!(dir_id.as_param()),
         ));
 
         for assignment in data.entity_attribute_assignments {
             stmts.push((
-                "INSERT INTO ent_attr (did, eid, attrid) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING".into(),
-                params!(did.as_param(), assignment.eid.as_param(), assignment.attrid.as_param()),
+                "INSERT INTO ent_attr (dir_id, eid, attrid) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING".into(),
+                params!(dir_id.as_param(), assignment.eid.as_param(), assignment.attrid.as_param()),
             ));
         }
     }
@@ -150,32 +193,32 @@ pub fn document_txn_statements(
     // service entity props
     {
         stmts.push(gc(
-            "svc_ent_prop",
-            NotIn("id", data.svc_ent_props.iter().map(|s| s.id)),
-            did,
+            "dom_ent_prop",
+            NotIn("id", data.domain_ent_props.iter().map(|s| s.id)),
+            dir_id,
         ));
         stmts.push(gc(
-            "svc_ent_attrlabel",
+            "dom_ent_attrlabel",
             NotIn(
                 "id",
-                data.svc_ent_props
+                data.domain_ent_props
                     .iter()
                     .flat_map(|p| p.attributes.iter())
                     .map(|a| a.id),
             ),
-            did,
+            dir_id,
         ));
 
-        for eprop in data.svc_ent_props {
+        for eprop in data.domain_ent_props {
             stmts.push((
-                "INSERT INTO svc_ent_prop (did, id, svc_eid, label) VALUES ($1, $2, $3, $4) ON CONFLICT DO UPDATE SET label = $4".into(),
-                params!(did.as_param(), eprop.id.as_param(), eprop.svc_eid.as_param(), &eprop.label),
+                "INSERT INTO dom_ent_prop (dir_id, id, dom_id, label) VALUES ($1, $2, $3, $4) ON CONFLICT DO UPDATE SET label = $4".into(),
+                params!(dir_id.as_param(), eprop.id.as_param(), eprop.dom_id.as_param(), &eprop.label),
             ));
 
             for attr in eprop.attributes {
                 stmts.push((
-                    "INSERT INTO svc_ent_attrlabel (did, id, prop_id, label) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING".into(),
-                    params!(did.as_param(), attr.id.as_param(), eprop.id.as_param(), attr.label)
+                    "INSERT INTO dom_ent_attrlabel (dir_id, id, prop_id, label) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING".into(),
+                    params!(dir_id.as_param(), attr.id.as_param(), eprop.id.as_param(), attr.label)
                 ));
             }
         }
@@ -184,44 +227,44 @@ pub fn document_txn_statements(
     // service resource props
     {
         stmts.push(gc(
-            "svc_res_prop",
-            NotIn("id", data.svc_res_props.iter().map(|p| p.id)),
-            did,
+            "dom_res_prop",
+            NotIn("id", data.domain_res_props.iter().map(|p| p.id)),
+            dir_id,
         ));
         stmts.push(gc(
-            "svc_res_attrlabel",
+            "dom_res_attrlabel",
             NotIn(
                 "id",
-                data.svc_res_props
+                data.domain_res_props
                     .iter()
                     .flat_map(|p| p.attributes.iter())
                     .map(|a| a.id),
             ),
-            did,
+            dir_id,
         ));
 
-        for rprop in data.svc_res_props {
+        for rprop in data.domain_res_props {
             stmts.push((
                 indoc! {
                     "
-                    INSERT INTO svc_res_prop (did, id, svc_eid, label)
+                    INSERT INTO dom_res_prop (dir_id, id, dom_id, label)
                     VALUES ($1, $2, $3, $4)
                     ON CONFLICT DO UPDATE SET label = $4
                     "
                 }
                 .into(),
                 params!(
-                    did.as_param(),
+                    dir_id.as_param(),
                     rprop.id.as_param(),
-                    rprop.svc_eid.as_param(),
+                    rprop.dom_id.as_param(),
                     &rprop.label
                 ),
             ));
 
             for attr in rprop.attributes {
                 stmts.push((
-                    "INSERT INTO svc_res_attrlabel (did, id, prop_id, label) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING".into(),
-                    params!(did.as_param(), attr.id.as_param(), rprop.id.as_param(), attr.label)
+                    "INSERT INTO dom_res_attrlabel (dir_id, id, prop_id, label) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING".into(),
+                    params!(dir_id.as_param(), attr.id.as_param(), rprop.id.as_param(), attr.label)
                 ));
             }
         }
@@ -230,25 +273,24 @@ pub fn document_txn_statements(
     // service policies
     {
         stmts.push(gc(
-            "svc_policy",
-            NotIn("id", data.svc_policies.iter().map(|p| p.id)),
-            did,
+            "policy",
+            NotIn("id", data.policies.iter().map(|p| *p.id())),
+            dir_id,
         ));
 
-        for policy in data.svc_policies {
+        for Identified(id, policy) in data.policies {
             stmts.push((
                 indoc! {
                     "
-                    INSERT INTO svc_policy (did, id, svc_eid, label, policy_pc)
-                    VALUES ($1, $2, $3, $4, $5)
-                    ON CONFLICT DO UPDATE SET label = $4, policy_pc = $5
+                    INSERT INTO policy (dir_id, id, label, policy_pc)
+                    VALUES ($1, $2, $3, $4)
+                    ON CONFLICT DO UPDATE SET label = $3, policy_pc = $4
                     "
                 }
                 .into(),
                 params!(
-                    did.as_param(),
-                    policy.id.as_param(),
-                    policy.svc_eid.as_param(),
+                    dir_id.as_param(),
+                    id.as_param(),
                     policy.label,
                     postcard::to_allocvec(&policy.policy).unwrap()
                 ),
@@ -258,34 +300,37 @@ pub fn document_txn_statements(
 
     // service policy bindings
     {
-        // not sure how to "GC" this?
+        // not sure how to "GC" these?
         stmts.push((
-            "DELETE FROM svc_policy_binding WHERE did = $1".into(),
-            params!(did.as_param()),
+            "DELETE FROM polbind_attr_match WHERE dir_id = $1".into(),
+            params!(dir_id.as_param()),
+        ));
+        // not sure how to "GC" these?
+        stmts.push((
+            "DELETE FROM polbind_policy WHERE dir_id = $1".into(),
+            params!(dir_id.as_param()),
         ));
 
-        for policy_binding in data.svc_policy_bindings {
-            stmts.push((
-                indoc! {
-                    "
-                    INSERT INTO svc_policy_binding (did, svc_eid, attr_matcher_pc, policy_ids_pc)
-                    VALUES ($1, $2, $3, $4)
-                    ON CONFLICT DO NOTHING
-                    "
-                }
-                .into(),
-                params!(
-                    did.as_param(),
-                    policy_binding.svc_eid.as_param(),
-                    postcard::to_allocvec(&policy_binding.attr_matcher).unwrap(),
-                    postcard::to_allocvec(&policy_binding.policies).unwrap()
-                ),
-            ));
+        for Identified(id, data) in data.policy_bindings {
+            for attr in data.attr_matcher {
+                stmts.push((
+                    "INSERT INTO polbind_attr_match (dir_id, polbind_id, attr_id) VALUES ($1, $2, $3)"
+                        .into(),
+                    params!(dir_id.as_param(), id.as_param(), attr.as_param()),
+                ));
+            }
+            for policy_id in data.policies {
+                stmts.push((
+                    "INSERT INTO polbind_policy (dir_id, polbind_id, policy_id) VALUES ($1, $2, $3)"
+                        .into(),
+                    params!(dir_id.as_param(), id.as_param(), policy_id.as_param()),
+                ));
+            }
         }
     }
 
-    for (stmt, _) in &stmts {
-        debug!("{stmt}");
+    for (idx, (stmt, _)) in stmts.iter().enumerate() {
+        debug!("{idx} {stmt}");
     }
 
     Ok(stmts)
@@ -296,14 +341,14 @@ struct NotIn<'a, I>(&'a str, I);
 fn gc(
     table: &str,
     NotIn(id, keep): NotIn<impl Iterator<Item = impl Literal>>,
-    did: Eid,
+    dir_id: ObjId,
 ) -> (Cow<'static, str>, Vec<Param>) {
     (
         format!(
-            "DELETE FROM {table} WHERE did = $1 AND {id} NOT IN ({})",
+            "DELETE FROM {table} WHERE dir_id = $1 AND {id} NOT IN ({})",
             keep.map(|value| value.literal()).format(", ")
         )
         .into(),
-        params!(did.as_param()),
+        params!(dir_id.as_param()),
     )
 }

--- a/src/db/document_db.rs
+++ b/src/db/document_db.rs
@@ -100,14 +100,14 @@ pub fn document_txn_statements(
 
         // not sure how to "GC" this?
         stmts.push((
-            "DELETE FROM ent_text_attr WHERE dir_id = $1".into(),
+            "DELETE FROM obj_text_attr WHERE dir_id = $1".into(),
             params!(dir_id.as_param()),
         ));
 
-        for text_prop in data.entity_text_attrs {
+        for text_prop in data.obj_text_attrs {
             stmts.push((
-                "INSERT INTO ent_text_attr (dir_id, eid, prop_id, value) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING".into(),
-                params!(dir_id.as_param(), text_prop.eid.as_param(), text_prop.prop_id.as_param(), text_prop.value),
+                "INSERT INTO obj_text_attr (dir_id, obj_id, prop_id, value) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING".into(),
+                params!(dir_id.as_param(), text_prop.obj_id.as_param(), text_prop.prop_id.as_param(), text_prop.value),
             ));
         }
     }

--- a/src/db/entity_db.rs
+++ b/src/db/entity_db.rs
@@ -34,8 +34,8 @@ pub async fn find_local_directory_entity_password_hash_by_entity_ident(
             .query_raw(
                 indoc! {
                     "
-                    SELECT ta.eid, ta.value FROM ent_text_attr ta
-                    JOIN ent_ident i ON ta.eid = i.eid
+                    SELECT ta.obj_id, ta.value FROM obj_text_attr ta
+                    JOIN ent_ident i ON i.eid = ta.obj_id
                     WHERE i.prop_id = $1 AND i.fingerprint = $2 AND ta.prop_id = $3
                     ",
                 }
@@ -53,7 +53,7 @@ pub async fn find_local_directory_entity_password_hash_by_entity_ident(
             return Ok(None);
         };
 
-        (row.get_id("eid"), row.get_text("value"))
+        (row.get_id("obj_id"), row.get_text("value"))
     };
 
     Ok(Some(EntityPasswordHash {

--- a/src/db/entity_db.rs
+++ b/src/db/entity_db.rs
@@ -65,7 +65,7 @@ pub async fn find_local_directory_entity_password_hash_by_entity_ident(
 #[expect(unused)]
 pub async fn try_insert_entity_credentials(
     deps: &impl Db,
-    did: Eid,
+    dir_id: Eid,
     eid: Eid,
     ident: String,
     secret: String,
@@ -82,8 +82,8 @@ pub async fn try_insert_entity_credentials(
 
     deps
         .execute(
-            "INSERT INTO entity_password (did, eid, hash) VALUES ($1, $2, $3) ON CONFLICT DO UPDATE SET hash = $3".into(),
-            params!(did.as_param(), eid.as_param(), secret_hash),
+            "INSERT INTO entity_password (dir_id, eid, hash) VALUES ($1, $2, $3) ON CONFLICT DO UPDATE SET hash = $3".into(),
+            params!(dir_id.as_param(), eid.as_param(), secret_hash),
         )
         .await?;
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,7 +1,30 @@
 pub mod authority_mandate_db;
 pub mod cryptography_db;
+pub mod directory_db;
 pub mod document_db;
 pub mod entity_db;
+pub mod policy_db;
 pub mod service_db;
 pub mod session_db;
 pub mod settings_db;
+
+#[derive(Debug)]
+pub struct Identified<I, D>(pub I, pub D);
+
+impl<I, D> Identified<I, D> {
+    pub fn id(&self) -> &I {
+        &self.0
+    }
+
+    pub fn data(&self) -> &D {
+        &self.1
+    }
+
+    pub fn data_mut(&mut self) -> &mut D {
+        &mut self.1
+    }
+
+    pub fn into_data(self) -> D {
+        self.1
+    }
+}

--- a/src/db/policy_db.rs
+++ b/src/db/policy_db.rs
@@ -1,0 +1,153 @@
+use std::collections::BTreeSet;
+
+use authly_common::{
+    id::{Eid, ObjId},
+    policy::{code::to_bytecode, engine::PolicyEngine},
+};
+use authly_db::{literal::Literal, param::AsParam, Db, DbError, DbResult, Row};
+use hiqlite::{params, Param};
+use indoc::indoc;
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::policy::{
+    compiler::{expr::Expr, PolicyCompiler},
+    PolicyOutcome,
+};
+
+use super::Identified;
+
+#[derive(Debug)]
+pub struct DbPolicy {
+    pub label: String,
+    pub policy: PolicyPostcard,
+}
+
+/// The structure of how a policy in stored in postcard format in the database
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PolicyPostcard {
+    pub outcome: PolicyOutcome,
+    pub expr: Expr,
+}
+
+#[derive(Debug)]
+pub struct DbPolicyBinding {
+    pub attr_matcher: BTreeSet<ObjId>,
+    pub policies: BTreeSet<ObjId>,
+}
+
+#[derive(Debug)]
+pub struct PoliciesWithBindings {
+    pub policies: Vec<Identified<ObjId, PolicyPostcard>>,
+    pub bindings: Vec<DbPolicyBinding>,
+}
+
+/// Load the policy engine for a service
+pub async fn load_svc_policy_engine(deps: &impl Db, svc_eid: Eid) -> DbResult<PolicyEngine> {
+    let policy_data = load_svc_policies_with_bindings(deps, svc_eid).await?;
+
+    debug!(?policy_data, ?svc_eid, "loaded policy data!!!!");
+
+    let mut policy_engine = PolicyEngine::default();
+
+    for Identified(id, policy_pc) in policy_data.policies {
+        let opcodes = PolicyCompiler::expr_to_opcodes(&policy_pc.expr, policy_pc.outcome);
+        let bytecode = to_bytecode(&opcodes);
+
+        policy_engine.add_policy(id, bytecode);
+    }
+
+    for DbPolicyBinding {
+        attr_matcher,
+        policies,
+    } in policy_data.bindings
+    {
+        if policies.len() > 1 {
+            for policy_id in policies {
+                policy_engine.add_policy_trigger(
+                    attr_matcher.iter().map(ObjId::to_any).collect(),
+                    policy_id,
+                );
+            }
+        } else if let Some(policy_id) = policies.into_iter().next() {
+            policy_engine
+                .add_policy_trigger(attr_matcher.iter().map(ObjId::to_any).collect(), policy_id);
+        }
+    }
+
+    Ok(policy_engine)
+}
+
+pub async fn load_svc_policies_with_bindings(
+    deps: &impl Db,
+    svc_id: Eid,
+) -> DbResult<PoliciesWithBindings> {
+    let bindings = list_svc_implied_policy_bindings(deps, svc_id).await?;
+
+    let policy_ids = BTreeSet::<ObjId>::from_iter(
+        bindings
+            .iter()
+            .flat_map(|binding| binding.policies.iter().copied()),
+    );
+
+    let policies = deps
+        .query_raw(
+            format!(
+                "SELECT id, policy_pc FROM policy WHERE id IN ({})",
+                policy_ids.iter().map(|id| id.literal()).format(", ")
+            )
+            .into(),
+            params!(),
+        )
+        .await?
+        .into_iter()
+        .map(|mut row| {
+            let id = row.get_id("id");
+
+            let policy_postcard: PolicyPostcard = postcard::from_bytes(&row.get_blob("policy_pc"))
+                .map_err(|err| {
+                    tracing::error!(?err, "policy expr postcard error");
+                    DbError::BinaryEncoding
+                })?;
+
+            Ok(Identified(id, policy_postcard))
+        })
+        .collect::<Result<_, DbError>>()?;
+
+    Ok(PoliciesWithBindings { bindings, policies })
+}
+
+async fn list_svc_implied_policy_bindings(
+    deps: &impl Db,
+    svc_id: Eid,
+) -> DbResult<Vec<DbPolicyBinding>> {
+    let rows = deps
+        .query_raw(
+            indoc! {
+                "
+                SELECT
+                    CAST(group_concat(pb_am.attr_id, '') AS BLOB) attr_matcher,
+                    CAST(group_concat(pb_pol.policy_id, '') AS BLOB) policies
+                FROM polbind_policy pb_pol
+                JOIN polbind_attr_match pb_am ON pb_am.polbind_id = pb_pol.polbind_id
+                JOIN dom_res_attrlabel ra ON ra.id = pb_am.attr_id
+                JOIN dom_res_prop rp ON rp.id = ra.prop_id
+                JOIN svc_domain sdom ON sdom.dom_id = rp.dom_id
+                WHERE sdom.svc_eid = $1
+                GROUP BY pb_pol.polbind_id
+                "
+            }
+            .into(),
+            params!(svc_id.as_param()),
+        )
+        .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|mut row| DbPolicyBinding {
+            attr_matcher: BTreeSet::from_iter(row.get_ids_concatenated("attr_matcher")),
+            policies: BTreeSet::from_iter(row.get_ids_concatenated("policies")),
+        })
+        .collect())
+}

--- a/src/db/service_db.rs
+++ b/src/db/service_db.rs
@@ -1,24 +1,10 @@
-use std::collections::{BTreeSet, HashMap};
-
-use authly_common::{
-    id::ObjId,
-    policy::{code::to_bytecode, engine::PolicyEngine},
-    service::PropertyMapping,
-};
-use authly_db::{literal::Literal, param::AsParam, Db, DbError, DbResult, Row};
+use authly_common::{id::ObjId, service::PropertyMapping};
+use authly_db::{literal::Literal, param::AsParam, Db, DbResult, Row};
 use hiqlite::{params, Param};
 use indoc::indoc;
-use serde::{Deserialize, Serialize};
 use tracing::warn;
 
-use crate::{
-    id::BuiltinID,
-    policy::{
-        compiler::{expr::Expr, PolicyCompiler},
-        PolicyOutcome,
-    },
-    Eid,
-};
+use crate::{id::BuiltinID, Eid};
 
 #[derive(Debug)]
 pub struct ServiceProperty {
@@ -30,28 +16,6 @@ pub struct ServiceProperty {
 pub enum ServicePropertyKind {
     Entity,
     Resource,
-}
-
-#[derive(Debug)]
-pub struct ServicePolicy {
-    pub id: ObjId,
-    pub svc_eid: Eid,
-    pub label: String,
-    pub policy: PolicyPostcard,
-}
-
-/// The structure of how a policy in stored in postcard format in the database
-#[derive(Serialize, Deserialize, Debug)]
-pub struct PolicyPostcard {
-    pub outcome: PolicyOutcome,
-    pub expr: Expr,
-}
-
-#[derive(Debug)]
-pub struct ServicePolicyBinding {
-    pub svc_eid: Eid,
-    pub attr_matcher: BTreeSet<ObjId>,
-    pub policies: BTreeSet<ObjId>,
 }
 
 pub async fn find_service_label_by_eid(deps: &impl Db, eid: Eid) -> DbResult<Option<String>> {
@@ -105,66 +69,6 @@ pub async fn find_service_eid_by_k8s_service_account_name(
     Ok(Some(row.get_id("eid")))
 }
 
-pub async fn list_service_properties(
-    deps: &impl Db,
-    did: Eid,
-    svc_eid: Eid,
-    property_kind: ServicePropertyKind,
-) -> DbResult<Vec<ServiceProperty>> {
-    let rows = match property_kind {
-        ServicePropertyKind::Entity => {
-            deps.query_raw(
-                indoc! {
-                    "
-                        SELECT p.id pid, p.label plabel, a.id attrid, a.label alabel
-                        FROM svc_ent_prop p
-                        JOIN svc_ent_attrlabel a ON a.prop_id = p.id
-                        WHERE p.did = $1 AND p.svc_eid = $2
-                        ",
-                }
-                .into(),
-                params!(did.as_param(), svc_eid.as_param()),
-            )
-            .await?
-        }
-        ServicePropertyKind::Resource => {
-            deps.query_raw(
-                indoc! {
-                    "
-                        SELECT p.id pid, p.label plabel, a.id attrid, a.label alabel
-                        FROM svc_res_prop p
-                        JOIN svc_res_attrlabel a ON a.prop_id = p.id
-                        WHERE p.did = $1 AND p.svc_eid = $2
-                        ",
-                }
-                .into(),
-                params!(did.as_param(), svc_eid.as_param()),
-            )
-            .await?
-        }
-    };
-
-    let mut properties: HashMap<ObjId, ServiceProperty> = Default::default();
-
-    for mut row in rows {
-        let prop_id = row.get_id("pid");
-
-        let property = properties
-            .entry(prop_id)
-            .or_insert_with(|| ServiceProperty {
-                id: prop_id,
-                label: row.get_text("plabel"),
-                attributes: vec![],
-            });
-
-        property
-            .attributes
-            .push((row.get_id("attrid"), row.get_text("alabel")));
-    }
-
-    Ok(properties.into_values().collect())
-}
-
 pub async fn get_service_property_mapping(
     deps: &impl Db,
     svc_eid: Eid,
@@ -176,9 +80,9 @@ pub async fn get_service_property_mapping(
                 indoc! {
                     "
                     SELECT p.id pid, p.label plabel, a.id attrid, a.label alabel
-                    FROM svc_ent_prop p
-                    JOIN svc_ent_attrlabel a ON a.prop_id = p.id
-                    WHERE p.svc_eid = $1
+                    FROM dom_ent_prop p
+                    JOIN dom_ent_attrlabel a ON a.prop_id = p.id
+                    WHERE p.dom_id = $1
                     ",
                 }
                 .into(),
@@ -191,9 +95,9 @@ pub async fn get_service_property_mapping(
                 indoc! {
                     "
                     SELECT p.id pid, p.label plabel, a.id attrid, a.label alabel
-                    FROM svc_res_prop p
-                    JOIN svc_res_attrlabel a ON a.prop_id = p.id
-                    WHERE p.svc_eid = $1
+                    FROM dom_res_prop p
+                    JOIN dom_res_attrlabel a ON a.prop_id = p.id
+                    WHERE p.dom_id = $1
                     ",
                 }
                 .into(),
@@ -214,96 +118,4 @@ pub async fn get_service_property_mapping(
     }
 
     Ok(mapping)
-}
-
-pub async fn list_service_policies(
-    deps: &impl Db,
-    did: Eid,
-    svc_eid: Eid,
-) -> DbResult<Vec<ServicePolicy>> {
-    let rows = deps
-        .query_raw(
-            "SELECT id, label, policy_pc FROM svc_policy WHERE did = $1 AND svc_eid = $2".into(),
-            params!(did.as_param(), svc_eid.as_param()),
-        )
-        .await?;
-
-    let mut policies = Vec::with_capacity(rows.len());
-
-    for mut row in rows {
-        let id = row.get_id("id");
-        let label = row.get_text("label");
-
-        let policy = postcard::from_bytes(&row.get_blob("policy_pc")).map_err(|err| {
-            tracing::error!(?err, "policy expr postcard error");
-            DbError::BinaryEncoding
-        })?;
-
-        policies.push(ServicePolicy {
-            id,
-            svc_eid,
-            label,
-            policy,
-        });
-    }
-
-    Ok(policies)
-}
-
-/// Load the policy engine for a service
-pub async fn load_policy_engine(deps: &impl Db, svc_eid: Eid) -> DbResult<PolicyEngine> {
-    let policy_rows = deps
-        .query_raw(
-            "SELECT id, policy_pc FROM svc_policy WHERE svc_eid = $1".into(),
-            params!(svc_eid.as_param()),
-        )
-        .await?;
-
-    let mut policy_engine = PolicyEngine::default();
-
-    for mut row in policy_rows {
-        let id = row.get_id("id");
-
-        let policy_postcard: PolicyPostcard = postcard::from_bytes(&row.get_blob("policy_pc"))
-            .map_err(|err| {
-                tracing::error!(?err, "policy expr postcard error");
-                DbError::BinaryEncoding
-            })?;
-
-        let opcodes =
-            PolicyCompiler::expr_to_opcodes(&policy_postcard.expr, policy_postcard.outcome);
-        let bytecode = to_bytecode(&opcodes);
-
-        policy_engine.add_policy(id, bytecode);
-    }
-
-    let binding_rows = deps
-        .query_raw(
-            "SELECT attr_matcher_pc, policy_ids_pc FROM svc_policy_binding WHERE svc_eid = $1"
-                .into(),
-            params!(svc_eid.as_param()),
-        )
-        .await?;
-
-    for mut row in binding_rows {
-        let attr_matcher_pc = row.get_blob("attr_matcher_pc");
-        let policy_ids_pc = row.get_blob("policy_ids_pc");
-
-        let attr_matcher: BTreeSet<ObjId> = postcard::from_bytes(&attr_matcher_pc).unwrap();
-        let policy_ids: BTreeSet<ObjId> = postcard::from_bytes(&policy_ids_pc).unwrap();
-
-        if policy_ids.len() > 1 {
-            for policy_id in policy_ids {
-                policy_engine.add_policy_trigger(
-                    attr_matcher.iter().map(ObjId::to_any).collect(),
-                    policy_id,
-                );
-            }
-        } else if let Some(policy_id) = policy_ids.into_iter().next() {
-            policy_engine
-                .add_policy_trigger(attr_matcher.iter().map(ObjId::to_any).collect(), policy_id);
-        }
-    }
-
-    Ok(policy_engine)
 }

--- a/src/db/service_db.rs
+++ b/src/db/service_db.rs
@@ -1,4 +1,4 @@
-use authly_common::{id::ObjId, service::PropertyMapping};
+use authly_common::{id::ObjId, service::NamespacePropertyMapping};
 use authly_db::{literal::Literal, param::AsParam, Db, DbResult, Row};
 use hiqlite::{params, Param};
 use indoc::indoc;
@@ -22,7 +22,7 @@ pub async fn find_service_label_by_eid(deps: &impl Db, eid: Eid) -> DbResult<Opt
     let Some(mut row) = deps
         .query_raw(
             format!(
-                "SELECT value FROM ent_text_attr WHERE eid = $1 AND prop_id = {prop_id}",
+                "SELECT value FROM obj_text_attr WHERE obj_id = $1 AND prop_id = {prop_id}",
                 prop_id = BuiltinID::PropLabel.to_obj_id().literal()
             )
             .into(),
@@ -49,7 +49,7 @@ pub async fn find_service_eid_by_k8s_service_account_name(
 ) -> DbResult<Option<Eid>> {
     let Some(mut row) = deps
         .query_raw(
-            "SELECT eid FROM ent_text_attr WHERE prop_id = $1 AND value = $2".into(),
+            "SELECT obj_id FROM obj_text_attr WHERE prop_id = $1 AND value = $2".into(),
             params!(
                 BuiltinID::PropK8sServiceAccount.to_obj_id().as_param(),
                 format!("{namespace}/{account_name}")
@@ -66,27 +66,32 @@ pub async fn find_service_eid_by_k8s_service_account_name(
         return Ok(None);
     };
 
-    Ok(Some(row.get_id("eid")))
+    Ok(Some(row.get_id("obj_id")))
 }
 
 pub async fn get_service_property_mapping(
     deps: &impl Db,
     svc_eid: Eid,
     property_kind: ServicePropertyKind,
-) -> DbResult<PropertyMapping> {
+) -> DbResult<NamespacePropertyMapping> {
     let rows = match property_kind {
         ServicePropertyKind::Entity => {
             deps.query_raw(
                 indoc! {
                     "
-                    SELECT p.id pid, p.label plabel, a.id attrid, a.label alabel
+                    SELECT ns.value ns, p.id pid, p.label plabel, a.id attrid, a.label alabel
                     FROM dom_ent_prop p
                     JOIN dom_ent_attrlabel a ON a.prop_id = p.id
-                    WHERE p.dom_id = $1
+                    JOIN svc_domain ON svc_domain.dom_id = p.dom_id
+                    JOIN obj_text_attr ns ON ns.obj_id = p.dom_id
+                    WHERE svc_domain.svc_eid = $1 AND ns.prop_id = $2
                     ",
                 }
                 .into(),
-                params!(svc_eid.as_param()),
+                params!(
+                    svc_eid.as_param(),
+                    BuiltinID::PropLabel.to_obj_id().as_param()
+                ),
             )
             .await?
         }
@@ -94,27 +99,31 @@ pub async fn get_service_property_mapping(
             deps.query_raw(
                 indoc! {
                     "
-                    SELECT p.id pid, p.label plabel, a.id attrid, a.label alabel
+                    SELECT ns.value ns, p.id pid, p.label plabel, a.id attrid, a.label alabel
                     FROM dom_res_prop p
                     JOIN dom_res_attrlabel a ON a.prop_id = p.id
-                    WHERE p.dom_id = $1
+                    JOIN svc_domain ON svc_domain.dom_id = p.dom_id
+                    JOIN obj_text_attr ns ON ns.obj_id = p.dom_id
+                    WHERE svc_domain.svc_eid = $1 AND ns.prop_id = $2
                     ",
                 }
                 .into(),
-                params!(svc_eid.as_param()),
+                params!(
+                    svc_eid.as_param(),
+                    BuiltinID::PropLabel.to_obj_id().as_param()
+                ),
             )
             .await?
         }
     };
 
-    let mut mapping = PropertyMapping::default();
+    let mut mapping = NamespacePropertyMapping::default();
 
     for mut row in rows {
-        let prop_label = row.get_text("plabel");
-        let attr_label = row.get_text("alabel");
-        let attr_id = row.get_id("attrid");
-
-        mapping.add(prop_label, attr_label, attr_id);
+        mapping
+            .namespace_mut(row.get_text("ns"))
+            .property_mut(row.get_text("plabel"))
+            .put(row.get_text("alabel"), row.get_id("attrid"));
     }
 
     Ok(mapping)

--- a/src/db/settings_db.rs
+++ b/src/db/settings_db.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use authly_common::id::Eid;
+use authly_common::id::ObjId;
 use authly_db::{Db, DbResult, Row};
 use hiqlite::params;
 
@@ -8,7 +8,7 @@ use crate::settings::{Setting, Settings};
 
 struct LocalSetting {
     #[expect(unused)]
-    did: Eid,
+    dir_id: ObjId,
     setting: Setting,
     value: String,
 }
@@ -16,7 +16,7 @@ struct LocalSetting {
 pub async fn load_local_settings(deps: &impl Db) -> DbResult<Settings> {
     let setting_list: Vec<_> = deps
         .query_raw(
-            "SELECT did, setting, value FROM local_setting".into(),
+            "SELECT dir_id, setting, value FROM local_setting".into(),
             params!(),
         )
         .await?
@@ -29,7 +29,7 @@ pub async fn load_local_settings(deps: &impl Db) -> DbResult<Settings> {
             };
 
             Some(LocalSetting {
-                did: row.get_id("did"),
+                dir_id: row.get_id("dir_id"),
                 setting,
                 value: row.get_text("value"),
             })
@@ -40,7 +40,7 @@ pub async fn load_local_settings(deps: &impl Db) -> DbResult<Settings> {
 
     for LocalSetting {
         // TODO: Sort settings based on directory importance:
-        did: _,
+        dir_id: _,
         setting,
         value,
     } in setting_list

--- a/src/document/compiled_document.rs
+++ b/src/document/compiled_document.rs
@@ -14,6 +14,7 @@ pub enum CompileError {
     LocalSettingNotFound,
     InvalidSettingValue(String),
     NameDefinedMultipleTimes(Range<usize>, String),
+    UnresolvedNamespace,
     UnresolvedEntity,
     UnresolvedProfile,
     UnresolvedGroup,

--- a/src/document/compiled_document.rs
+++ b/src/document/compiled_document.rs
@@ -60,12 +60,14 @@ pub struct CompiledDocumentData {
     pub entity_attribute_assignments: Vec<CompiledEntityAttributeAssignment>,
 
     pub entity_ident: Vec<EntityIdent>,
-    pub entity_text_attrs: Vec<EntityTextAttr>,
+    pub obj_text_attrs: Vec<ObjectTextAttr>,
     pub entity_password: Vec<EntityPassword>,
 
     pub service_ids: BTreeSet<Eid>,
 
+    // TODO: remove
     pub domains: Vec<Identified<ObjId, String>>,
+
     pub service_domains: Vec<(Eid, AnyId)>,
 
     pub entity_relations: Vec<CompiledEntityRelation>,
@@ -84,9 +86,10 @@ pub struct EntityIdent {
     pub ident: String,
 }
 
+// note: This is not only for entities
 #[derive(Debug)]
-pub struct EntityTextAttr {
-    pub eid: Eid,
+pub struct ObjectTextAttr {
+    pub obj_id: AnyId,
     pub prop_id: ObjId,
     pub value: String,
 }

--- a/src/document/doc_compiler.rs
+++ b/src/document/doc_compiler.rs
@@ -3,18 +3,20 @@ use std::collections::hash_map::Entry;
 use std::{cmp, mem};
 use std::{collections::HashMap, ops::Range};
 
+use authly_common::id::AnyId;
 use authly_common::{
     document,
     id::{Eid, ObjId},
     property::QualifiedAttributeName,
 };
-use authly_db::Db;
+use authly_db::{Db, DbError};
 use serde::de::value::StrDeserializer;
 use serde::Deserialize;
 use serde_spanned::Spanned;
 use tracing::debug;
 
-use crate::db::service_db;
+use crate::db::policy_db::DbPolicy;
+use crate::db::{directory_db, policy_db, service_db, Identified};
 use crate::document::compiled_document::{
     CompiledEntityAttributeAssignment, EntityIdent, EntityTextAttr,
 };
@@ -22,6 +24,7 @@ use crate::id::BuiltinID;
 use crate::policy::compiler::PolicyCompiler;
 use crate::policy::PolicyOutcome;
 use crate::settings::{Setting, Settings};
+use crate::util::error::{HandleError, ResultExt};
 
 use super::compiled_document::{
     CompileError, CompiledAttribute, CompiledDocument, CompiledDocumentData,
@@ -75,19 +78,20 @@ pub enum NamespaceKind {
     Authly,
     Entity(Eid),
     Service(Eid),
-    Domain,
+    Domain(ObjId),
     Policy(ObjId),
 }
 
 struct CompileCtx {
     /// Directory ID
-    did: Eid,
+    dir_id: ObjId,
 
     namespaces: Namespaces,
 
-    eprop_cache: HashMap<Eid, Vec<service_db::ServiceProperty>>,
-    rprop_cache: HashMap<Eid, Vec<service_db::ServiceProperty>>,
-    policy_cache: HashMap<Eid, Vec<service_db::ServicePolicy>>,
+    eprop_cache: HashMap<AnyId, Vec<service_db::ServiceProperty>>,
+    rprop_cache: HashMap<AnyId, Vec<service_db::ServiceProperty>>,
+    policy_cache: HashMap<ObjId, Vec<Identified<ObjId, policy_db::DbPolicy>>>,
+    domain_cache: Option<HashMap<String, ObjId>>,
 
     errors: Errors,
 }
@@ -108,11 +112,12 @@ pub async fn compile_doc(
     db: &impl Db,
 ) -> Result<CompiledDocument, Vec<Spanned<CompileError>>> {
     let mut comp = CompileCtx {
-        did: Eid::from_uint(doc.authly_document.id.get_ref().as_u128()),
+        dir_id: ObjId::from_uint(doc.authly_document.id.get_ref().as_u128()),
         namespaces: Default::default(),
         eprop_cache: Default::default(),
         rprop_cache: Default::default(),
         policy_cache: Default::default(),
+        domain_cache: Default::default(),
         errors: Default::default(),
     };
     let mut data = CompiledDocumentData {
@@ -148,7 +153,24 @@ pub async fn compile_doc(
         }
     }
 
-    seed_namespace(&doc, &mut comp);
+    {
+        seed_namespace(&doc, &mut comp);
+
+        for domain in mem::take(&mut doc.domain) {
+            let Some(cache) = comp.db_directory_domains_cache(db).await else {
+                continue;
+            };
+
+            let id = cache
+                .get(domain.label.as_ref())
+                .copied()
+                .unwrap_or_else(ObjId::random);
+
+            comp.ns_add(&domain.label, NamespaceKind::Domain(id));
+
+            data.domains.push(Identified(id, domain.label.into_inner()));
+        }
+    }
 
     debug!("namespace: {:#?}", comp.namespaces.table);
 
@@ -230,11 +252,20 @@ pub async fn compile_doc(
     )
     .await;
 
+    for doc_svc_domain in doc.service_domain {
+        if let (Some(svc_eid), Some(dom_id)) = (
+            comp.ns_entity_lookup(&doc_svc_domain.service),
+            comp.ns_domain_lookup(&doc_svc_domain.domain),
+        ) {
+            data.service_domains.push((svc_eid, dom_id));
+        }
+    }
+
     if !comp.errors.errors.is_empty() {
         Err(comp.errors.errors)
     } else {
         Ok(CompiledDocument {
-            did: comp.did,
+            dir_id: comp.dir_id,
             meta,
             data,
         })
@@ -351,13 +382,13 @@ async fn process_service_properties(
     db: &impl Db,
 ) {
     for doc_eprop in entity_properties {
-        if let Some(svc_label) = &doc_eprop.service {
-            let Some(svc_eid) = comp.ns_service_lookup(svc_label) else {
+        if let Some(domain_label) = &doc_eprop.domain {
+            let Some(svc_eid) = comp.ns_domain_lookup(domain_label) else {
                 continue;
             };
 
             if let Some(compiled_property) = compile_service_property(
-                &svc_label,
+                domain_label,
                 svc_eid,
                 service_db::ServicePropertyKind::Entity,
                 &doc_eprop.label,
@@ -367,19 +398,19 @@ async fn process_service_properties(
             )
             .await
             {
-                data.svc_ent_props.push(compiled_property);
+                data.domain_ent_props.push(compiled_property);
             }
         }
     }
 
     for doc_rprop in resource_properties {
-        let Some(svc_eid) = comp.ns_service_lookup(&doc_rprop.service) else {
+        let Some(domain_eid) = comp.ns_domain_lookup(&doc_rprop.domain) else {
             continue;
         };
 
         if let Some(compiled_property) = compile_service_property(
-            &doc_rprop.service,
-            svc_eid,
+            &doc_rprop.domain,
+            domain_eid,
             service_db::ServicePropertyKind::Resource,
             &doc_rprop.label,
             doc_rprop.attributes,
@@ -388,14 +419,14 @@ async fn process_service_properties(
         )
         .await
         {
-            data.svc_res_props.push(compiled_property);
+            data.domain_res_props.push(compiled_property);
         }
     }
 }
 
 async fn compile_service_property(
     svc_namespace: &Spanned<String>,
-    svc_eid: Eid,
+    dom_id: AnyId,
     property_kind: service_db::ServicePropertyKind,
     doc_property_label: &Spanned<String>,
     doc_attributes: Vec<Spanned<String>>,
@@ -403,7 +434,7 @@ async fn compile_service_property(
     db: &impl Db,
 ) -> Option<CompiledProperty> {
     let db_props_cached = comp
-        .db_service_properties_cached(svc_eid, property_kind, db)
+        .db_domain_properties_cached(dom_id, property_kind, db)
         .await?;
 
     let db_eprop = db_props_cached
@@ -415,7 +446,7 @@ async fn compile_service_property(
             .as_ref()
             .map(|db_prop| db_prop.id)
             .unwrap_or_else(ObjId::random),
-        svc_eid,
+        dom_id,
         label: doc_property_label.as_ref().to_string(),
         attributes: vec![],
     };
@@ -494,10 +525,6 @@ async fn process_policies(
     db: &impl Db,
 ) {
     for policy in policies {
-        let Some(svc_eid) = comp.ns_service_lookup(&policy.service) else {
-            continue;
-        };
-
         let (src, outcome) = match (policy.allow, policy.deny) {
             (Some(src), None) => (src, PolicyOutcome::Allow),
             (None, Some(src)) => (src, PolicyOutcome::Deny),
@@ -534,31 +561,34 @@ async fn process_policies(
             }
         };
 
-        let db_cache = comp.db_service_policies_cached(svc_eid, db).await;
+        let db_cache = comp.db_directory_policies_cached(db).await;
         let cached_policy = db_cache
             .iter()
             .flat_map(|c| c.iter())
-            .find(|db_policy| &db_policy.label == policy.label.as_ref());
+            .find(|db_policy| &db_policy.data().label == policy.label.as_ref());
 
-        let policy_postcard = service_db::PolicyPostcard { outcome, expr };
+        let policy_postcard = policy_db::PolicyPostcard { outcome, expr };
 
         let namespace_label = policy.label.as_ref().to_string();
         let label_span = policy.label.span();
 
-        let service_policy = if let Some(cached_policy) = cached_policy {
-            service_db::ServicePolicy {
-                id: cached_policy.id,
-                svc_eid,
-                label: policy.label.into_inner(),
-                policy: policy_postcard,
-            }
+        let service_policy: Identified<ObjId, DbPolicy> = if let Some(cached_policy) = cached_policy
+        {
+            Identified(
+                *cached_policy.id(),
+                policy_db::DbPolicy {
+                    label: policy.label.into_inner(),
+                    policy: policy_postcard,
+                },
+            )
         } else {
-            service_db::ServicePolicy {
-                id: ObjId::random(),
-                svc_eid,
-                label: policy.label.into_inner(),
-                policy: policy_postcard,
-            }
+            Identified(
+                ObjId::random(),
+                policy_db::DbPolicy {
+                    label: policy.label.into_inner(),
+                    policy: policy_postcard,
+                },
+            )
         };
 
         comp.namespaces.table.insert(
@@ -566,13 +596,13 @@ async fn process_policies(
             Spanned::new(
                 label_span,
                 Namespace {
-                    kind: NamespaceKind::Policy(service_policy.id),
+                    kind: NamespaceKind::Policy(*service_policy.id()),
                     entries: Default::default(),
                 },
             ),
         );
 
-        data.svc_policies.push(service_policy);
+        data.policies.push(service_policy);
     }
 }
 
@@ -582,15 +612,13 @@ fn process_policy_bindings(
     comp: &mut CompileCtx,
 ) {
     for binding in policy_bindings {
-        let Some(svc_eid) = comp.ns_service_lookup(&binding.service) else {
-            continue;
-        };
-
-        let mut svc_policy_binding = service_db::ServicePolicyBinding {
-            svc_eid,
-            attr_matcher: Default::default(),
-            policies: Default::default(),
-        };
+        let mut policy_binding = Identified(
+            ObjId::random(),
+            policy_db::DbPolicyBinding {
+                attr_matcher: Default::default(),
+                policies: Default::default(),
+            },
+        );
 
         for spanned_qattr in binding.attributes {
             let Some(prop_id) = comp.ns_property_lookup(
@@ -610,7 +638,7 @@ fn process_policy_bindings(
                     }
                 };
 
-            svc_policy_binding.attr_matcher.insert(attr_id);
+            policy_binding.data_mut().attr_matcher.insert(attr_id);
         }
 
         for spanned_policy in binding.policies {
@@ -618,10 +646,10 @@ fn process_policy_bindings(
                 continue;
             };
 
-            svc_policy_binding.policies.insert(policy_id);
+            policy_binding.data_mut().policies.insert(policy_id);
         }
 
-        data.svc_policy_bindings.push(svc_policy_binding);
+        data.policy_bindings.push(policy_binding);
     }
 }
 
@@ -690,9 +718,10 @@ impl CompileCtx {
         }
     }
 
-    fn ns_service_lookup(&mut self, key: &Spanned<impl AsRef<str>>) -> Option<Eid> {
+    fn ns_domain_lookup(&mut self, key: &Spanned<impl AsRef<str>>) -> Option<AnyId> {
         match self.ns_lookup_kind(key, CompileError::UnresolvedService)? {
-            NamespaceKind::Service(eid) => Some(*eid),
+            NamespaceKind::Service(eid) => Some(AnyId::from_array(&eid.to_bytes())),
+            NamespaceKind::Domain(dom_id) => Some(AnyId::from_array(&dom_id.to_bytes())),
             _ => {
                 self.errors
                     .push(key.span(), CompileError::UnresolvedService);
@@ -758,9 +787,9 @@ impl CompileCtx {
         }
     }
 
-    async fn db_service_properties_cached<'s>(
+    async fn db_domain_properties_cached<'s>(
         &'s mut self,
-        svc_eid: Eid,
+        dom_id: AnyId,
         property_kind: service_db::ServicePropertyKind,
         db: &impl Db,
     ) -> Option<&'s Vec<service_db::ServiceProperty>> {
@@ -769,46 +798,55 @@ impl CompileCtx {
             service_db::ServicePropertyKind::Resource => &mut self.rprop_cache,
         };
 
-        match cache.entry(svc_eid) {
+        match cache.entry(dom_id) {
             Entry::Occupied(occupied) => Some(occupied.into_mut()),
             Entry::Vacant(vacant) => {
                 let db_props =
-                    match service_db::list_service_properties(db, self.did, svc_eid, property_kind)
+                    directory_db::list_domain_properties(db, self.dir_id, dom_id, property_kind)
                         .await
-                    {
-                        Ok(db_props) => db_props,
-                        Err(e) => {
-                            self.errors.push(0..0, CompileError::Db(e.to_string()));
-                            return None;
-                        }
-                    };
-
+                        .handle_err(&mut self.errors)?;
                 Some(vacant.insert(db_props))
             }
         }
     }
 
-    async fn db_service_policies_cached<'s>(
+    async fn db_directory_policies_cached<'s>(
         &'s mut self,
-        svc_eid: Eid,
         db: &impl Db,
-    ) -> Option<&'s Vec<service_db::ServicePolicy>> {
+    ) -> Option<&'s Vec<Identified<ObjId, policy_db::DbPolicy>>> {
         let cache = &mut self.policy_cache;
 
-        match cache.entry(svc_eid) {
+        match cache.entry(self.dir_id) {
             Entry::Occupied(occupied) => Some(occupied.into_mut()),
             Entry::Vacant(vacant) => {
-                let db_props = match service_db::list_service_policies(db, self.did, svc_eid).await
-                {
-                    Ok(db_props) => db_props,
-                    Err(e) => {
-                        self.errors.push(0..0, CompileError::Db(e.to_string()));
-                        return None;
-                    }
-                };
+                let db_policies = directory_db::directory_list_policies(db, self.dir_id)
+                    .await
+                    .handle_err(&mut self.errors)?;
 
-                Some(vacant.insert(db_props))
+                Some(vacant.insert(db_policies))
             }
+        }
+    }
+
+    async fn db_directory_domains_cache<'s>(
+        &'s mut self,
+        db: &impl Db,
+    ) -> Option<&'s HashMap<String, ObjId>> {
+        if self.domain_cache.is_some() {
+            Some(self.domain_cache.as_mut().unwrap())
+        } else {
+            let db_domains = directory_db::directory_list_domains(db, self.dir_id)
+                .await
+                .handle_err(&mut self.errors)?;
+
+            Some(
+                self.domain_cache.insert(
+                    db_domains
+                        .into_iter()
+                        .map(|Identified(id, label)| (label, id))
+                        .collect(),
+                ),
+            )
         }
     }
 }
@@ -816,6 +854,12 @@ impl CompileCtx {
 impl Errors {
     fn push(&mut self, span: Range<usize>, error: CompileError) {
         self.errors.push(Spanned::new(span, error));
+    }
+}
+
+impl HandleError<DbError> for Errors {
+    fn handle(&mut self, error: DbError) {
+        self.push(0..0, CompileError::from(error));
     }
 }
 

--- a/src/document/load.rs
+++ b/src/document/load.rs
@@ -1,7 +1,7 @@
 use std::{fs, os::unix::ffi::OsStrExt};
 
 use anyhow::anyhow;
-use authly_common::{document::Document, id::Eid};
+use authly_common::{document::Document, id::ObjId};
 use tracing::info;
 
 use crate::{
@@ -52,9 +52,9 @@ pub(crate) async fn load_cfg_documents(
                 },
             };
 
-            let did = Eid::from_uint(document.authly_document.id.get_ref().as_u128());
+            let dir_id = ObjId::from_uint(document.authly_document.id.get_ref().as_u128());
 
-            if should_process(did, &meta, &doc_authorities) {
+            if should_process(dir_id, &meta, &doc_authorities) {
                 info!(?path, "load");
 
                 let compiled_doc = match compile_doc(document, meta, ctx.get_db()).await {
@@ -77,13 +77,17 @@ pub(crate) async fn load_cfg_documents(
     Ok(())
 }
 
-fn should_process(did: Eid, meta: &DocumentMeta, doc_authorities: &[DocumentDirectory]) -> bool {
-    for auth in doc_authorities {
-        if auth.did != did {
+fn should_process(
+    dir_id: ObjId,
+    meta: &DocumentMeta,
+    doc_directories: &[DocumentDirectory],
+) -> bool {
+    for dir in doc_directories {
+        if dir.dir_id != dir_id {
             continue;
         }
 
-        if auth.hash == meta.hash {
+        if dir.hash == meta.hash {
             return false;
         }
     }

--- a/src/id.rs
+++ b/src/id.rs
@@ -53,7 +53,7 @@ impl BuiltinID {
         match self {
             Self::Authly => None,
             Self::PropEntity => Some("entity"),
-            Self::PropAuthlyRole => Some("authly:role"),
+            Self::PropAuthlyRole => Some("role"),
             Self::AttrAuthlyRoleGetAccessToken => Some("get_access_token"),
             Self::AttrAuthlyRoleAuthenticate => Some("authenticate"),
             Self::AttrAuthlyRoleApplyDocument => Some("apply_document"),

--- a/src/policy/compiler.rs
+++ b/src/policy/compiler.rs
@@ -9,7 +9,7 @@ use pest::{
     Parser,
 };
 
-use crate::document::{compiled_document::CompiledDocumentData, doc_compiler::Namespace};
+use crate::document::{compiled_document::CompiledDocumentData, doc_compiler::Namespaces};
 
 use super::{
     error::{PolicyCompileError, PolicyCompileErrorKind},
@@ -23,7 +23,7 @@ mod parse_check;
 mod parser;
 
 pub struct PolicyCompiler<'a> {
-    namespace: &'a Namespace,
+    namespace: &'a Namespaces,
     doc_data: &'a CompiledDocumentData,
     outcome: PolicyOutcome,
 
@@ -37,7 +37,7 @@ struct ParseCtx {
 
 impl<'a> PolicyCompiler<'a> {
     pub fn new(
-        namespace: &'a Namespace,
+        namespace: &'a Namespaces,
         doc_data: &'a CompiledDocumentData,
         outcome: PolicyOutcome,
     ) -> Self {

--- a/src/policy/compiler/parser.rs
+++ b/src/policy/compiler/parser.rs
@@ -23,50 +23,50 @@ mod policy_tests {
 
     #[test]
     fn policy_field_equals_label() {
-        parse_policy_ok("Subject.entity == testservice");
+        parse_policy_ok("Subject.a:entity == testservice");
     }
 
     #[test]
     fn policy_field_contains_attribute() {
-        parse_policy_ok("Subject.role contains a/b");
-        parse_policy_ok("Subject.role contains foo/bar");
+        parse_policy_ok("Subject.a:role contains a:b:c");
+        parse_policy_ok("Subject.a:role contains foo:bar:baz");
     }
 
     #[test]
     fn policy_conjunction() {
-        parse_policy_ok("Subject.role contains a/b and Resource.name == foo");
+        parse_policy_ok("Subject.a:role contains a:b:c and Resource.a:name == foo");
     }
 
     #[test]
     fn policy_disjuction() {
-        parse_policy_ok("Subject.role contains a/b or Resource.name == foo");
+        parse_policy_ok("Subject.a:role contains a:b:c or Resource.a:name == foo");
     }
 
     #[test]
     fn policy_not() {
-        parse_policy_ok("not Subject.role contains a/b");
+        parse_policy_ok("not Subject.a:role contains a:b:c");
     }
 
     #[test]
     fn policy_not_conj() {
-        parse_policy_ok("not Subject.role contains a/b and not a == b");
+        parse_policy_ok("not Subject.a:role contains a:b:c and not a == b");
     }
 
     #[test]
     fn policy_not_conj_parenthesized() {
-        parse_policy_ok("(not Subject.role contains a/b) and (not a == b)");
+        parse_policy_ok("(not Subject.a:role contains a:b:c) and (not a == b)");
     }
 
     #[test]
     fn policy_parenthesized() {
         parse_policy_ok(
-            "(Subject.role contains a/b and Resource.name == foo) or Subject.b == label",
+            "(Subject.a:role contains a:b:c and Resource.a:name == foo) or Subject.a:b == label",
         );
     }
 
     #[test]
     fn policy_print_tree() {
-        let foo = parse_policy_ok("(not Subject.role contains a/b) and (not a == b)")
+        let foo = parse_policy_ok("(not Subject.a:role contains a:b:c) and (not a == b)")
             .into_inner()
             .next()
             .unwrap();

--- a/src/policy/error.rs
+++ b/src/policy/error.rs
@@ -16,6 +16,9 @@ pub enum PolicyCompileErrorKind {
     #[error("unknown label: {0}")]
     UnknownLabel(String),
 
+    #[error("unknown namespace")]
+    UnknownNamespace(String),
+
     #[error("unknown property")]
     UnknownProperty(String),
 

--- a/src/policy/test_compile.rs
+++ b/src/policy/test_compile.rs
@@ -3,7 +3,7 @@ use super::compiler::{
     PolicyCompiler,
 };
 use authly_common::{
-    id::{Eid, ObjId},
+    id::{AnyId, Eid, ObjId},
     policy::code::OpCode,
 };
 
@@ -38,9 +38,9 @@ fn test_env() -> (Namespaces, CompiledDocumentData) {
         ),
     ]);
     let mut doc_data = CompiledDocumentData::default();
-    doc_data.svc_ent_props.push(CompiledProperty {
+    doc_data.domain_ent_props.push(CompiledProperty {
         id: ROLE,
-        svc_eid: SVC,
+        dom_id: AnyId::from_array(&SVC.to_bytes()),
         label: "role".to_string(),
         attributes: vec![CompiledAttribute {
             id: ROLE_ROOT,

--- a/src/policy/test_compile.rs
+++ b/src/policy/test_compile.rs
@@ -10,7 +10,7 @@ use authly_common::{
 use crate::{
     document::{
         compiled_document::{CompiledAttribute, CompiledDocumentData, CompiledProperty},
-        doc_compiler::{Namespace, NamespaceEntry},
+        doc_compiler::{NamespaceEntry, NamespaceKind, Namespaces},
     },
     id::BuiltinID,
 };
@@ -21,14 +21,21 @@ const SVC: Eid = Eid::from_uint(42);
 const ROLE: ObjId = ObjId::from_uint(1337);
 const ROLE_ROOT: ObjId = ObjId::from_uint(1338);
 
-fn test_env() -> (Namespace, CompiledDocumentData) {
-    let namespace = Namespace::from_iter([
+fn test_env() -> (Namespaces, CompiledDocumentData) {
+    let namespace = Namespaces::from_iter([
         (
-            "entity".to_string(),
-            NamespaceEntry::PropertyLabel(BuiltinID::PropEntity.to_obj_id()),
+            "a".to_string(),
+            NamespaceKind::Service(SVC),
+            vec![(
+                "entity".to_string(),
+                NamespaceEntry::PropertyLabel(BuiltinID::PropEntity.to_obj_id()),
+            )],
         ),
-        ("svc".to_string(), NamespaceEntry::Service(SVC)),
-        ("role".to_string(), NamespaceEntry::PropertyLabel(ROLE)),
+        (
+            "svc".to_string(),
+            NamespaceKind::Service(SVC),
+            vec![("role".to_string(), NamespaceEntry::PropertyLabel(ROLE))],
+        ),
     ]);
     let mut doc_data = CompiledDocumentData::default();
     doc_data.svc_ent_props.push(CompiledProperty {
@@ -44,6 +51,7 @@ fn test_env() -> (Namespace, CompiledDocumentData) {
     (namespace, doc_data)
 }
 
+#[track_caller]
 fn to_expr(src: &str) -> Expr {
     let (namespace, doc_data) = test_env();
     PolicyCompiler::new(&namespace, &doc_data, PolicyOutcome::Allow)
@@ -52,6 +60,7 @@ fn to_expr(src: &str) -> Expr {
         .0
 }
 
+#[track_caller]
 fn to_opcodes(src: &str) -> Vec<OpCode> {
     let (namespace, doc_data) = test_env();
     PolicyCompiler::new(&namespace, &doc_data, PolicyOutcome::Allow)
@@ -74,7 +83,7 @@ fn subject_entity_equals_svc() -> Expr {
 fn test_expr_equals() {
     assert_eq!(
         subject_entity_equals_svc(),
-        to_expr("Subject.entity == svc")
+        to_expr("Subject.a:entity == svc")
     );
 }
 
@@ -85,7 +94,7 @@ fn test_expr_field_attribute() {
             Term::Field(Global::Subject, Label(ROLE.to_bytes())),
             Term::Attr(Label(ROLE.to_bytes()), Label(ROLE_ROOT.to_bytes()))
         ),
-        to_expr("Subject.role contains role/root")
+        to_expr("Subject.svc:role contains svc:role:root")
     );
 }
 
@@ -93,7 +102,7 @@ fn test_expr_field_attribute() {
 fn test_expr_not() {
     assert_eq!(
         Expr::not(subject_entity_equals_svc()),
-        to_expr("not Subject.entity == svc")
+        to_expr("not Subject.a:entity == svc")
     );
 }
 
@@ -104,7 +113,7 @@ fn test_expr_logical_precedence() {
             Expr::and(subject_entity_equals_svc(), subject_entity_equals_svc()),
             subject_entity_equals_svc()
         ),
-        to_expr("Subject.entity == svc and Subject.entity == svc or Subject.entity == svc")
+        to_expr("Subject.a:entity == svc and Subject.a:entity == svc or Subject.a:entity == svc")
     );
 }
 
@@ -115,7 +124,7 @@ fn test_expr_logical_precedence2() {
             subject_entity_equals_svc(),
             Expr::and(subject_entity_equals_svc(), subject_entity_equals_svc()),
         ),
-        to_expr("Subject.entity == svc or Subject.entity == svc and Subject.entity == svc")
+        to_expr("Subject.a:entity == svc or Subject.a:entity == svc and Subject.a:entity == svc")
     );
 }
 
@@ -126,7 +135,7 @@ fn test_expr_logical_paren() {
             subject_entity_equals_svc(),
             Expr::or(subject_entity_equals_svc(), subject_entity_equals_svc()),
         ),
-        to_expr("Subject.entity == svc and (Subject.entity == svc or Subject.entity == svc)")
+        to_expr("Subject.a:entity == svc and (Subject.a:entity == svc or Subject.a:entity == svc)")
     );
 }
 
@@ -147,6 +156,8 @@ fn test_opcodes() {
             OpCode::Or,
             OpCode::TrueThenAllow,
         ],
-        to_opcodes("Subject.entity == svc and Subject.entity == svc or Subject.entity == svc")
+        to_opcodes(
+            "Subject.a:entity == svc and Subject.a:entity == svc or Subject.a:entity == svc"
+        )
     );
 }

--- a/src/proto/service_server.rs
+++ b/src/proto/service_server.rs
@@ -25,7 +25,7 @@ use crate::{
     access_token,
     ctx::{GetDb, GetInstance},
     db::{
-        entity_db,
+        entity_db, policy_db,
         service_db::{self, find_service_label_by_eid, ServicePropertyKind},
     },
     id::BuiltinID,
@@ -197,7 +197,7 @@ impl AuthlyService for AuthlyServiceServerImpl {
         }
 
         // TODO: Should definitely cache service policy engine in memory
-        let policy_engine = service_db::load_policy_engine(self.ctx.get_db(), peer_svc_eid)
+        let policy_engine = policy_db::load_svc_policy_engine(self.ctx.get_db(), peer_svc_eid)
             .await
             .map_err(grpc_db_err)?;
 

--- a/src/util/error.rs
+++ b/src/util/error.rs
@@ -1,0 +1,19 @@
+pub trait ResultExt<T, E> {
+    fn handle_err(self, handler: &mut impl HandleError<E>) -> Option<T>;
+}
+
+impl<T, E> ResultExt<T, E> for Result<T, E> {
+    fn handle_err(self, handler: &mut impl HandleError<E>) -> Option<T> {
+        match self {
+            Ok(value) => Some(value),
+            Err(error) => {
+                handler.handle(error);
+                None
+            }
+        }
+    }
+}
+
+pub trait HandleError<E> {
+    fn handle(&mut self, error: E);
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod base_uri;
+pub mod error;
 pub mod protocol_router;
 pub mod remote_addr;
 pub mod serde;

--- a/tests/integration/end2end/test_auth_access_control.rs
+++ b/tests/integration/end2end/test_auth_access_control.rs
@@ -100,7 +100,7 @@ async fn auth_session_cookie_to_access_token() -> anyhow::Result<()> {
     {
         let Err(authly_client::Error::InvalidPropertyAttributeLabel) = authly_client
             .access_control_request()
-            .resource_attribute("bogus", "pomp")
+            .resource_attribute("fake", "bogus", "pomp")
         else {
             panic!("incorrect error");
         };
@@ -110,7 +110,7 @@ async fn auth_session_cookie_to_access_token() -> anyhow::Result<()> {
     {
         let outcome = authly_client
             .access_control_request()
-            .resource_attribute("ontology/action", "read")?
+            .resource_attribute("testservice", "ontology/action", "read")?
             .access_token(access_token.clone())
             .send()
             .await
@@ -123,7 +123,7 @@ async fn auth_session_cookie_to_access_token() -> anyhow::Result<()> {
     {
         let outcome = authly_client
             .access_control_request()
-            .resource_attribute("ontology/action", "deploy")?
+            .resource_attribute("testservice", "ontology/action", "deploy")?
             .access_token(access_token.clone())
             .send()
             .await

--- a/tests/integration/end2end/test_auth_access_control.rs
+++ b/tests/integration/end2end/test_auth_access_control.rs
@@ -110,7 +110,7 @@ async fn auth_session_cookie_to_access_token() -> anyhow::Result<()> {
     {
         let outcome = authly_client
             .access_control_request()
-            .resource_attribute("ontology:action", "read")?
+            .resource_attribute("ontology/action", "read")?
             .access_token(access_token.clone())
             .send()
             .await
@@ -123,7 +123,7 @@ async fn auth_session_cookie_to_access_token() -> anyhow::Result<()> {
     {
         let outcome = authly_client
             .access_control_request()
-            .resource_attribute("ontology:action", "deploy")?
+            .resource_attribute("ontology/action", "deploy")?
             .access_token(access_token.clone())
             .send()
             .await

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -14,7 +14,7 @@ use authly::{
 };
 use authly_common::{
     document::Document, id::Eid, proto::connect::authly_connect_server::AuthlyConnectServer,
-    service::PropertyMapping,
+    service::NamespacePropertyMapping,
 };
 use authly_connect::{
     server::{AuthlyConnectServerImpl, ConnectService},
@@ -164,8 +164,8 @@ async fn spawn_test_server_cancellable(service: axum::Router, cancel: Cancellati
 }
 
 struct ServiceProperties {
-    resource: PropertyMapping,
-    entity: PropertyMapping,
+    resource: NamespacePropertyMapping,
+    entity: NamespacePropertyMapping,
 }
 
 impl ServiceProperties {

--- a/tests/integration/test_access_control.rs
+++ b/tests/integration/test_access_control.rs
@@ -96,8 +96,8 @@ async fn test_access_control_basic() {
             Outcome::Deny,
             engine
                 .eval(&AccessControlParams {
-                    resource_attrs: props.resource.translate([("kind", "trousers")]),
-                    subject_attrs: props.entity.translate([("trait", "has_legs")]),
+                    resource_attrs: props.resource.translate([("svc_a", "kind", "trousers")]),
+                    subject_attrs: props.entity.translate([("svc_a", "trait", "has_legs")]),
                     ..Default::default()
                 })
                 .unwrap(),
@@ -110,7 +110,7 @@ async fn test_access_control_basic() {
                 .eval(&AccessControlParams {
                     resource_attrs: props
                         .resource
-                        .translate([("kind", "trousers"), ("verb", "wear")]),
+                        .translate([("svc_a", "kind", "trousers"), ("svc_a", "verb", "wear")]),
                     ..Default::default()
                 })
                 .unwrap(),
@@ -123,8 +123,8 @@ async fn test_access_control_basic() {
                 .eval(&AccessControlParams {
                     resource_attrs: props
                         .resource
-                        .translate([("kind", "trousers"), ("verb", "wear")]),
-                    subject_attrs: props.entity.translate([("trait", "has_legs")]),
+                        .translate([("svc_a", "kind", "trousers"), ("svc_a", "verb", "wear")]),
+                    subject_attrs: props.entity.translate([("svc_a", "trait", "has_legs")]),
                     ..Default::default()
                 })
                 .unwrap(),

--- a/tests/integration/test_access_control.rs
+++ b/tests/integration/test_access_control.rs
@@ -46,11 +46,11 @@ async fn test_access_control_basic() {
         [[policy]]
         service = "svc_a"
         label = "allow for legged creatures"
-        allow = "Subject.trait == trait/has_legs"
+        allow = "Subject.svc_a:trait == svc_a:trait:has_legs"
 
         [[policy-binding]]
         service = "svc_a"
-        attributes = ["kind/trousers", "verb/wear"]
+        attributes = ["svc_a:kind:trousers", "svc_a:verb:wear"]
         policies = ["allow for legged creatures"]
         "#
     })

--- a/tests/integration/test_access_control.rs
+++ b/tests/integration/test_access_control.rs
@@ -1,6 +1,9 @@
-use authly::{ctx::GetDb, db::service_db, test_ctx::TestCtx};
+use authly::{
+    ctx::GetDb,
+    db::policy_db::{self, load_svc_policies_with_bindings},
+    test_ctx::TestCtx,
+};
 use authly_common::{
-    document::Document,
     id::{AnyId, Eid},
     policy::{code::Outcome, engine::AccessControlParams},
 };
@@ -12,10 +15,10 @@ use crate::{compile_and_apply_doc, ServiceProperties};
 const SVC_A: Eid = Eid::from_array(hex_literal!("e5462a0d22b54d9f9ca37bd96e9b9d8b"));
 const SVC_B: Eid = Eid::from_array(hex_literal!("015362d6655447c6b7f44865bd111c70"));
 
-#[tokio::test]
+#[test_log::test(tokio::test)]
 async fn test_access_control_basic() {
     let ctx = TestCtx::default().inmemory_db().await;
-    let doc = Document::from_toml(indoc! {
+    let doc = indoc! {
         r#"
         [authly-document]
         id = "bc9ce588-50c3-47d1-94c1-f88b21eaf299"
@@ -29,39 +32,36 @@ async fn test_access_control_basic() {
         label = "svc_b"
 
         [[entity-property]]
-        service = "svc_a"
+        domain = "svc_a"
         label = "trait"
         attributes = ["has_legs"]
 
         [[resource-property]]
-        service = "svc_a"
+        domain = "svc_a"
         label = "kind"
         attributes = ["trousers"]
 
         [[resource-property]]
-        service = "svc_a"
+        domain = "svc_a"
         label = "verb"
         attributes = ["wear"]
 
         [[policy]]
-        service = "svc_a"
         label = "allow for legged creatures"
         allow = "Subject.svc_a:trait == svc_a:trait:has_legs"
 
         [[policy-binding]]
-        service = "svc_a"
         attributes = ["svc_a:kind:trousers", "svc_a:verb:wear"]
         policies = ["allow for legged creatures"]
         "#
-    })
-    .unwrap();
+    };
 
     compile_and_apply_doc(doc, &Default::default(), &ctx)
         .await
         .unwrap();
 
     {
-        let engine = service_db::load_policy_engine(ctx.get_db(), SVC_A)
+        let engine = policy_db::load_svc_policy_engine(ctx.get_db(), SVC_A)
             .await
             .unwrap();
         let props = ServiceProperties::load(SVC_A, ctx.get_db()).await;
@@ -133,10 +133,96 @@ async fn test_access_control_basic() {
     }
 
     {
-        let svc_b_policy_engine = service_db::load_policy_engine(ctx.get_db(), SVC_B)
+        let svc_b_policy_engine = policy_db::load_svc_policy_engine(ctx.get_db(), SVC_B)
             .await
             .unwrap();
         assert_eq!(0, svc_b_policy_engine.get_policy_count());
         assert_eq!(0, svc_b_policy_engine.get_trigger_count());
     }
+}
+
+/// This tests the logic for determining which policy bindings (attribute matchers) are relevant
+/// to a service depends correctly on the set of domains the service participates in.
+#[test_log::test(tokio::test)]
+async fn test_svc_domain_implied_policies() {
+    let ctx = TestCtx::default().inmemory_db().await;
+    let doc = indoc! {
+        r#"
+        [authly-document]
+        id = "bc9ce588-50c3-47d1-94c1-f88b21eaf299"
+
+        [[domain]]
+        label = "foo"
+        [[domain]]
+        label = "bar"
+
+        [[service-entity]]
+        eid = "e5462a0d22b54d9f9ca37bd96e9b9d8b"
+        label = "svc_a"
+
+        [[service-entity]]
+        eid = "015362d6655447c6b7f44865bd111c70"
+        label = "svc_b"
+
+        [[service-domain]]
+        service = "svc_a"
+        domain = "foo"
+
+        [[service-domain]]
+        service = "svc_b"
+        domain = "foo"
+
+        [[service-domain]]
+        service = "svc_b"
+        domain = "bar"
+
+        [[resource-property]]
+        domain = "foo"
+        label = "fooA"
+        attributes = ["fooA"]
+        [[resource-property]]
+        domain = "foo"
+        label = "fooB"
+        attributes = ["fooB"]
+
+        [[resource-property]]
+        domain = "bar"
+        label = "barA"
+        attributes = ["barA"]
+        [[resource-property]]
+        domain = "bar"
+        label = "barB"
+        attributes = ["barB"]
+
+        [[policy]]
+        label = "pol1"
+        allow = "Subject.authly:entity == svc_a"
+
+        [[policy]]
+        label = "pol2"
+        allow = "Subject.authly:entity == svc_b"
+
+        [[policy-binding]]
+        attributes = ["foo:fooA:fooA", "foo:fooB:fooB"]
+        policies = ["pol1"]
+
+        [[policy-binding]]
+        attributes = ["bar:barA:barA", "bar:barB:barB"]
+        policies = ["pol2"]
+        "#
+    };
+
+    compile_and_apply_doc(doc, &Default::default(), &ctx)
+        .await
+        .unwrap();
+
+    let pol_a = load_svc_policies_with_bindings(ctx.get_db(), SVC_A)
+        .await
+        .unwrap();
+    assert_eq!(pol_a.policies.len(), 1);
+
+    let pol_b = load_svc_policies_with_bindings(ctx.get_db(), SVC_B)
+        .await
+        .unwrap();
+    assert_eq!(pol_b.policies.len(), 2);
 }

--- a/tests/integration/test_document.rs
+++ b/tests/integration/test_document.rs
@@ -19,7 +19,7 @@ async fn test_store_doc_trivial() {
         [[service-entity]]
         eid = "e5462a0d22b54d9f9ca37bd96e9b9d8b"
         label = "service1"
-        attributes = ["authly:role/authenticate", "authly:role/get_access_token"]
+        attributes = ["authly:role:authenticate", "authly:role:get_access_token"]
         kubernetes-account = { name = "testservice", namespace = "authly-test" }
 
         [[service-entity]]

--- a/tests/integration/test_document.rs
+++ b/tests/integration/test_document.rs
@@ -2,7 +2,6 @@ use authly::{
     ctx::GetDb,
     db::{entity_db, service_db},
 };
-use authly_common::document::Document;
 use hexhex::hex_literal;
 use indoc::indoc;
 
@@ -11,7 +10,7 @@ use crate::{compile_and_apply_doc, TestCtx};
 #[tokio::test]
 async fn test_store_doc_trivial() {
     let ctx = TestCtx::default().inmemory_db().await;
-    let doc = Document::from_toml(indoc! {
+    let doc = indoc! {
         r#"
         [authly-document]
         id = "bc9ce588-50c3-47d1-94c1-f88b21eaf299"
@@ -26,8 +25,7 @@ async fn test_store_doc_trivial() {
         eid = "015362d6655447c6b7f44865bd111c70"
         label = "service2"
         "#
-    })
-    .unwrap();
+    };
 
     compile_and_apply_doc(doc, &Default::default(), &ctx)
         .await


### PR DESCRIPTION
Proposed syntax change, with mandatory namespacing. Still working on the underlying `domain` model.

I'm torn on the natural separator token. It used to be `/` but here it's changed into using `:` which feels more "namespacy"?