### PR TITLE
ID revamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "authly-client"
 version = "0.0.5"
-source = "git+https://github.com/protojour/authly-lib.git#25632869e28067daf3372c7dceada7efb16322a6"
+source = "git+https://github.com/protojour/authly-lib.git#736aa47ff197324e3f1b691638a91c60eb68bfa6"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 name = "authly-common"
 version = "0.0.5"
-source = "git+https://github.com/protojour/authly-lib.git#25632869e28067daf3372c7dceada7efb16322a6"
+source = "git+https://github.com/protojour/authly-lib.git#736aa47ff197324e3f1b691638a91c60eb68bfa6"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/benches/authly_benches.rs
+++ b/benches/authly_benches.rs
@@ -4,7 +4,7 @@ use authly::{
     session::{Session, SessionToken},
     test_support::TestCtx,
 };
-use authly_common::id::{Eid, ObjId};
+use authly_common::id::{AttrId, Eid};
 use criterion::{criterion_group, criterion_main, Criterion};
 use fnv::FnvHashSet;
 use time::{Duration, OffsetDateTime};
@@ -16,7 +16,7 @@ pub fn authly_benchmark(c: &mut Criterion) {
         eid: Eid::random(),
         expires_at: OffsetDateTime::now_utc() + Duration::days(42),
     };
-    let user_attributes = FnvHashSet::from_iter([ObjId::random(), ObjId::random()]);
+    let user_attributes = FnvHashSet::from_iter([AttrId::random(), AttrId::random()]);
     let instance = ctx.load_instance();
 
     c.bench_function("generate_access_token", |b| {

--- a/examples/0_rudiments.toml
+++ b/examples/0_rudiments.toml
@@ -9,7 +9,7 @@ SERVER_CERT_ROTATION_RATE = "3m"
 # The gateway is responsible for opening up the public aspects of Authly
 # to the world outside the cluster:
 [[service-entity]]
-eid = "3c2f40b3f47a4d9b9129b1e7c15fbc04"
+eid = "e.3c2f40b3f47a4d9b9129b1e7c15fbc04"
 label = "arx"
 attributes = ["authly:role:authenticate", "authly:role:get_access_token"]
 kubernetes-account = { name = "arx", namespace = "authly-test" }

--- a/examples/1_testusers.toml
+++ b/examples/1_testusers.toml
@@ -2,7 +2,7 @@
 id = "d783648f-e6ac-4492-87f7-43d5e5805d60"
 
 [[entity]]
-eid = "0fbcd73e1a884424a1615c3c3fdeebec"
+eid = "e.0fbcd73e1a884424a1615c3c3fdeebec"
 label = "me"
 email = ["me@mail.com"]
 username = "testuser"
@@ -11,11 +11,11 @@ password-hash = [
 ]
 
 [[entity]]
-eid = "81dc1da0fa644142bad35043a9c3b025"
+eid = "e.81dc1da0fa644142bad35043a9c3b025"
 label = "us"
 
 [[entity]]
-eid = "96bf83f88cbf455fa356553f7fca1b9e"
+eid = "e.96bf83f88cbf455fa356553f7fca1b9e"
 label = "you"
 
 [[members]]

--- a/examples/2_testservice.toml
+++ b/examples/2_testservice.toml
@@ -2,7 +2,7 @@
 id = "bc9ce588-50c3-47d1-94c1-f88b21eaf299"
 
 [[service-entity]]
-eid = "f3e799137c034e1eb4cd3e4f65705932"
+eid = "e.f3e799137c034e1eb4cd3e4f65705932"
 label = "testservice"
 attributes = ["authly:role:authenticate", "authly:role:get_access_token"]
 kubernetes-account = { name = "testservice", namespace = "authly-test" }
@@ -13,11 +13,11 @@ label = "role"
 attributes = ["ui/user", "ui/admin"]
 
 [[entity-attribute-binding]]
-eid = "0fbcd73e1a884424a1615c3c3fdeebec"
+eid = "e.0fbcd73e1a884424a1615c3c3fdeebec"
 attributes = ["testservice:role:ui/user"]
 
 [[entity-attribute-binding]]
-eid = "96bf83f88cbf455fa356553f7fca1b9e"
+eid = "e.96bf83f88cbf455fa356553f7fca1b9e"
 attributes = ["testservice:role:ui/admin"]
 
 [[resource-property]]

--- a/lib/authly-db/src/literal.rs
+++ b/lib/authly-db/src/literal.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use authly_common::id::{kind::IdKind, Id128, Id128DynamicArrayConv};
+use authly_common::id::{kind::IdKind, AnyId, Id128, Id128DynamicArrayConv};
 
 pub trait Literal {
     type Lit: Display;
@@ -9,6 +9,14 @@ pub trait Literal {
 }
 
 impl<K: IdKind> Literal for Id128<K> {
+    type Lit = IdLiteral;
+
+    fn literal(&self) -> Self::Lit {
+        IdLiteral(self.to_array_dynamic())
+    }
+}
+
+impl Literal for AnyId {
     type Lit = IdLiteral;
 
     fn literal(&self) -> Self::Lit {

--- a/lib/authly-db/src/literal.rs
+++ b/lib/authly-db/src/literal.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use authly_common::id::Id128;
+use authly_common::id::{kind::IdKind, Id128, Id128DynamicArrayConv};
 
 pub trait Literal {
     type Lit: Display;
@@ -8,15 +8,15 @@ pub trait Literal {
     fn literal(&self) -> Self::Lit;
 }
 
-impl<K> Literal for Id128<K> {
+impl<K: IdKind> Literal for Id128<K> {
     type Lit = IdLiteral;
 
     fn literal(&self) -> Self::Lit {
-        IdLiteral(self.to_bytes())
+        IdLiteral(self.to_array_dynamic())
     }
 }
 
-pub struct IdLiteral([u8; 16]);
+pub struct IdLiteral([u8; 17]);
 
 impl Display for IdLiteral {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/lib/authly-db/src/param.rs
+++ b/lib/authly-db/src/param.rs
@@ -1,11 +1,17 @@
-use authly_common::id::Id128;
+use authly_common::id::{kind::IdKind, AnyId, Id128, Id128DynamicArrayConv};
 
 pub trait AsParam: Sized {
     fn as_param(&self) -> hiqlite::Param;
 }
 
-impl<K> AsParam for Id128<K> {
+impl<K: IdKind> AsParam for Id128<K> {
     fn as_param(&self) -> hiqlite::Param {
-        hiqlite::Param::Blob(self.to_bytes().to_vec())
+        hiqlite::Param::Blob(self.to_array_dynamic().to_vec())
+    }
+}
+
+impl AsParam for AnyId {
+    fn as_param(&self) -> hiqlite::Param {
+        hiqlite::Param::Blob(self.to_array_dynamic().to_vec())
     }
 }

--- a/migrations/1_init.sql
+++ b/migrations/1_init.sql
@@ -92,6 +92,13 @@ CREATE TABLE obj_text_attr (
     PRIMARY KEY (obj_id, prop_id)
 );
 
+-- An object's label in its originating directory/document
+CREATE TABLE obj_label (
+    dir_id BLOB NOT NULL,
+    obj_id BLOB NOT NULL PRIMARY KEY,
+    label TEXT NOT NULL
+);
+
 -- Namespace: entity property
 CREATE TABLE ns_ent_prop (
     dir_id BLOB NOT NULL,

--- a/migrations/1_init.sql
+++ b/migrations/1_init.sql
@@ -35,6 +35,9 @@ CREATE TABLE directory (
     kind TEXT NOT NULL,
     url TEXT,
     hash BLOB
+    -- created_at DATETIME NOT NULL,
+    -- created_by_eid BLOB NOT NULL,
+    -- updated_at DATETIME NOT NULL
 );
 
 CREATE TABLE local_setting (
@@ -78,6 +81,8 @@ CREATE TABLE ent_rel (
     PRIMARY KEY (rel_id, subject_eid, object_eid)
 );
 
+-- Text attributes for any database object
+-- TODO: Labels can move into a separate table since they require directory-oriented indexing?
 CREATE TABLE obj_text_attr (
     dir_id BLOB NOT NULL,
     obj_id BLOB NOT NULL,
@@ -87,26 +92,18 @@ CREATE TABLE obj_text_attr (
     PRIMARY KEY (obj_id, prop_id)
 );
 
--- Domain: Property namespaces (not entities)
--- TODO: This table is not needed (obj_text_attr will be enough when ID can tag the underlying type)
-CREATE TABLE domain (
+-- Namespace: entity property
+CREATE TABLE ns_ent_prop (
     dir_id BLOB NOT NULL,
     id BLOB NOT NULL PRIMARY KEY,
-    label TEXT NOT NULL
-);
-
--- Domain: entity property
-CREATE TABLE dom_ent_prop (
-    dir_id BLOB NOT NULL,
-    id BLOB NOT NULL PRIMARY KEY,
-    dom_id BLOB NOT NULL,
+    ns_id BLOB NOT NULL,
     label TEXT NOT NULL,
 
-    UNIQUE (dom_id, label)
+    UNIQUE (ns_id, label)
 );
 
--- Domain: entity property attribute label
-CREATE TABLE dom_ent_attrlabel (
+-- Namespace: entity property attribute label
+CREATE TABLE ns_ent_attrlabel (
     dir_id BLOB NOT NULL,
     id BLOB NOT NULL,
     prop_id BLOB NOT NULL,
@@ -115,18 +112,18 @@ CREATE TABLE dom_ent_attrlabel (
     UNIQUE (prop_id, label)
 );
 
--- Domain: resource property
-CREATE TABLE dom_res_prop (
+-- Namespace: resource property
+CREATE TABLE ns_res_prop (
     dir_id BLOB NOT NULL,
     id BLOB NOT NULL PRIMARY KEY,
-    dom_id BLOB NOT NULL,
+    ns_id BLOB NOT NULL,
     label TEXT NOT NULL,
 
-    UNIQUE (dom_id, label)
+    UNIQUE (ns_id, label)
 );
 
--- Domain: resource attribute label
-CREATE TABLE dom_res_attrlabel (
+-- Namespace: resource attribute label
+CREATE TABLE ns_res_attrlabel (
     dir_id BLOB NOT NULL,
     id BLOB NOT NULL PRIMARY KEY,
     prop_id BLOB NOT NULL,
@@ -135,16 +132,16 @@ CREATE TABLE dom_res_attrlabel (
     UNIQUE (prop_id, label)
 );
 
--- Service: domain participation
-CREATE TABLE svc_domain (
+-- Service: namespace participation
+CREATE TABLE svc_namespace (
     dir_id BLOB NOT NULL,
     svc_eid BLOB NOT NULL,
-    dom_id BLOB NOT NULL,
+    ns_id BLOB NOT NULL,
 
-    PRIMARY KEY (svc_eid, dom_id)
+    PRIMARY KEY (svc_eid, ns_id)
 );
 
--- TODO: Should policies be associated to domains (as a namespace)?
+-- TODO: Should policies be associated to namespaces?
 CREATE TABLE policy (
     dir_id BLOB NOT NULL,
     id BLOB NOT NULL PRIMARY KEY,

--- a/src/access_token.rs
+++ b/src/access_token.rs
@@ -8,7 +8,7 @@
 
 use authly_common::{
     access_token::{Authly, AuthlyAccessTokenClaims},
-    id::ObjId,
+    id::AttrId,
 };
 use axum::RequestPartsExt;
 use axum_extra::{
@@ -35,7 +35,7 @@ pub enum AccessTokenError {
 /// There's a benchmark for it which reveals it runs in about 30 µs on my development machine.
 pub fn create_access_token(
     session: &Session,
-    user_attributes: FnvHashSet<ObjId>,
+    user_attributes: FnvHashSet<AttrId>,
     instance: &AuthlyInstance,
 ) -> Result<String, AccessTokenError> {
     let jwt_header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);

--- a/src/authority_mandate/submission.rs
+++ b/src/authority_mandate/submission.rs
@@ -99,5 +99,5 @@ impl TryFrom<(proto::AuthlyCertificate, AuthlyCertKind)> for AuthlyCert {
 }
 
 fn read_id(bytes: &[u8]) -> anyhow::Result<Eid> {
-    Eid::from_bytes(bytes).ok_or_else(|| anyhow!("invalid ID"))
+    Eid::from_raw_bytes(bytes).ok_or_else(|| anyhow!("invalid ID"))
 }

--- a/src/bus/message.rs
+++ b/src/bus/message.rs
@@ -1,4 +1,4 @@
-use authly_common::id::ObjId;
+use authly_common::id::DirectoryId;
 use serde::{Deserialize, Serialize};
 
 /// Message type used by the Authly message bus (hiqlite notify mechanism).
@@ -17,7 +17,7 @@ pub enum ClusterMessage {
     /// It can also mean the directory was added or removed.
     DirectoryChanged {
         /// The directory ID that changed
-        dir_id: ObjId,
+        dir_id: DirectoryId,
     },
 
     /// Broadcast message to all connected clients

--- a/src/db/directory_db.rs
+++ b/src/db/directory_db.rs
@@ -7,8 +7,6 @@ use authly_db::{param::AsParam, Db, DbResult, FromRow, Row, TryFromRow};
 use hiqlite::{params, Param};
 use indoc::indoc;
 
-use crate::id::BuiltinProp;
-
 use super::{
     policy_db::DbPolicy,
     service_db::{ServiceProperty, ServicePropertyKind},
@@ -32,11 +30,8 @@ impl DbDirectoryObjectLabel {
     pub async fn query(deps: &impl Db, dir_id: DirectoryId) -> DbResult<Vec<Self>> {
         deps.query_map(
             // FIXME: unindexed query
-            "SELECT obj_id, value FROM obj_text_attr WHERE dir_id = $1 AND prop_id = $2".into(),
-            params!(
-                dir_id.as_param(),
-                PropId::from(BuiltinProp::Label).as_param()
-            ),
+            "SELECT obj_id, label FROM obj_label WHERE dir_id = $1".into(),
+            params!(dir_id.as_param()),
         )
         .await
     }

--- a/src/db/directory_db.rs
+++ b/src/db/directory_db.rs
@@ -2,42 +2,48 @@
 
 use std::collections::HashMap;
 
-use authly_common::id::{AnyId, ObjId};
+use authly_common::id::{AnyId, AttrId, DirectoryId, PolicyId, PropId};
 use authly_db::{param::AsParam, Db, DbResult, FromRow, Row, TryFromRow};
 use hiqlite::{params, Param};
 use indoc::indoc;
+
+use crate::id::BuiltinProp;
 
 use super::{
     policy_db::DbPolicy,
     service_db::{ServiceProperty, ServicePropertyKind},
 };
 
-pub struct DbDirectoryDomain {
-    pub id: ObjId,
+pub struct DbDirectoryObjectLabel {
+    pub id: AnyId,
     pub label: String,
 }
 
-impl FromRow for DbDirectoryDomain {
+impl FromRow for DbDirectoryObjectLabel {
     fn from_row(row: &mut impl Row) -> Self {
         Self {
             id: row.get_id("id"),
-            label: row.get_text("label"),
+            label: row.get_text("value"),
         }
     }
 }
 
-impl DbDirectoryDomain {
-    pub async fn query(deps: &impl Db, dir_id: ObjId) -> DbResult<Vec<Self>> {
+impl DbDirectoryObjectLabel {
+    pub async fn query(deps: &impl Db, dir_id: DirectoryId) -> DbResult<Vec<Self>> {
         deps.query_map(
-            "SELECT id, label FROM domain WHERE dir_id = $1".into(),
-            params!(dir_id.as_param()),
+            // FIXME: unindexed query
+            "SELECT obj_id, value FROM obj_text_attr WHERE dir_id = $1 AND prop_id = $2".into(),
+            params!(
+                dir_id.as_param(),
+                PropId::from(BuiltinProp::Label).as_param()
+            ),
         )
         .await
     }
 }
 
 pub struct DbDirectoryPolicy {
-    pub id: ObjId,
+    pub id: PolicyId,
     pub policy: DbPolicy,
 }
 
@@ -56,7 +62,7 @@ impl TryFromRow for DbDirectoryPolicy {
 }
 
 impl DbDirectoryPolicy {
-    pub async fn query(deps: &impl Db, dir_id: ObjId) -> DbResult<Vec<Self>> {
+    pub async fn query(deps: &impl Db, dir_id: DirectoryId) -> DbResult<Vec<Self>> {
         deps.query_filter_map(
             "SELECT id, label, policy_pc FROM policy WHERE dir_id = $1".into(),
             params!(dir_id.as_param()),
@@ -65,13 +71,13 @@ impl DbDirectoryPolicy {
     }
 }
 
-pub async fn list_domain_properties(
+pub async fn list_namespace_properties(
     deps: &impl Db,
-    dir_id: ObjId,
-    dom_id: AnyId,
+    dir_id: DirectoryId,
+    ns_id: AnyId,
     property_kind: ServicePropertyKind,
 ) -> DbResult<Vec<ServiceProperty>> {
-    struct Output((ObjId, String), (ObjId, String));
+    struct Output((PropId, String), (AttrId, String));
 
     impl FromRow for Output {
         fn from_row(row: &mut impl Row) -> Self {
@@ -88,13 +94,13 @@ pub async fn list_domain_properties(
                 indoc! {
                     "
                     SELECT p.id pid, p.label plabel, a.id attrid, a.label alabel
-                    FROM dom_ent_prop p
-                    JOIN dom_ent_attrlabel a ON a.prop_id = p.id
-                    WHERE p.dir_id = $1 AND p.dom_id = $2
+                    FROM ns_ent_prop p
+                    JOIN ns_ent_attrlabel a ON a.prop_id = p.id
+                    WHERE p.dir_id = $1 AND p.ns_id = $2
                     ",
                 }
                 .into(),
-                params!(dir_id.as_param(), dom_id.as_param()),
+                params!(dir_id.as_param(), ns_id.as_param()),
             )
             .await?
         }
@@ -103,19 +109,19 @@ pub async fn list_domain_properties(
                 indoc! {
                     "
                     SELECT p.id pid, p.label plabel, a.id attrid, a.label alabel
-                    FROM dom_res_prop p
-                    JOIN dom_res_attrlabel a ON a.prop_id = p.id
-                    WHERE p.dir_id = $1 AND p.dom_id = $2
+                    FROM ns_res_prop p
+                    JOIN ns_res_attrlabel a ON a.prop_id = p.id
+                    WHERE p.dir_id = $1 AND p.ns_id = $2
                     ",
                 }
                 .into(),
-                params!(dir_id.as_param(), dom_id.as_param()),
+                params!(dir_id.as_param(), ns_id.as_param()),
             )
             .await?
         }
     };
 
-    let mut properties: HashMap<ObjId, ServiceProperty> = Default::default();
+    let mut properties: HashMap<PropId, ServiceProperty> = Default::default();
 
     for Output((prop_id, plabel), (attr_id, alabel)) in outputs {
         let property = properties

--- a/src/db/document_db.rs
+++ b/src/db/document_db.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use tracing::debug;
 
 use crate::{
-    document::compiled_document::CompiledDocument,
+    document::compiled_document::{CompiledDocument, ObjectLabel},
     encryption::{random_nonce, DecryptedDeks},
 };
 
@@ -109,6 +109,19 @@ pub fn document_txn_statements(
             stmts.push((
                 "INSERT INTO obj_text_attr (dir_id, obj_id, prop_id, value) VALUES ($1, $2, $3, $4) ON CONFLICT DO NOTHING".into(),
                 params!(dir_id.as_param(), text_prop.obj_id.as_param(), text_prop.prop_id.as_param(), text_prop.value),
+            ));
+        }
+
+        stmts.push(gc(
+            "obj_label",
+            NotIn("obj_id", data.obj_labels.iter().map(|label| label.obj_id)),
+            dir_id,
+        ));
+
+        for ObjectLabel { obj_id, label } in data.obj_labels {
+            stmts.push((
+                "INSERT INTO obj_label (dir_id, obj_id, label) VALUES ($1, $2, $3)".into(),
+                params!(dir_id.as_param(), obj_id.as_param(), label),
             ));
         }
     }

--- a/src/db/entity_db.rs
+++ b/src/db/entity_db.rs
@@ -1,21 +1,21 @@
 use argon2::{password_hash::SaltString, Argon2};
-use authly_common::id::{Eid, ObjId};
+use authly_common::id::{AttrId, Eid, PropId};
 use authly_db::{param::AsParam, Db, DbResult, FromRow, Row};
 use fnv::FnvHashSet;
 use hiqlite::{params, Param};
 use indoc::indoc;
 
-use crate::id::BuiltinID;
+use crate::id::BuiltinProp;
 
 pub struct EntityPasswordHash {
     pub eid: Eid,
     pub secret_hash: String,
 }
 
-pub struct EntityAttrs(pub FnvHashSet<ObjId>);
+pub struct EntityAttrs(pub FnvHashSet<AttrId>);
 
-pub async fn list_entity_attrs(deps: &impl Db, eid: Eid) -> DbResult<FnvHashSet<ObjId>> {
-    struct EntityAttr(ObjId);
+pub async fn list_entity_attrs(deps: &impl Db, eid: Eid) -> DbResult<FnvHashSet<AttrId>> {
+    struct EntityAttr(AttrId);
 
     impl FromRow for EntityAttr {
         fn from_row(row: &mut impl Row) -> Self {
@@ -45,7 +45,7 @@ impl FromRow for EntityPasswordHash {
 
 pub async fn find_local_directory_entity_password_hash_by_entity_ident(
     deps: &impl Db,
-    ident_prop_id: ObjId,
+    ident_prop_id: PropId,
     ident_fingerprint: &[u8],
 ) -> DbResult<Option<EntityPasswordHash>> {
     deps.query_map_opt(
@@ -60,7 +60,7 @@ pub async fn find_local_directory_entity_password_hash_by_entity_ident(
         params!(
             ident_prop_id.as_param(),
             ident_fingerprint,
-            BuiltinID::PropPasswordHash.to_obj_id().as_param()
+            PropId::from(BuiltinProp::PasswordHash).as_param()
         ),
     )
     .await

--- a/src/db/service_db.rs
+++ b/src/db/service_db.rs
@@ -2,7 +2,7 @@ use authly_common::{
     id::{AttrId, PropId},
     service::NamespacePropertyMapping,
 };
-use authly_db::{literal::Literal, param::AsParam, Db, DbResult, FromRow, Row};
+use authly_db::{param::AsParam, Db, DbResult, FromRow, Row};
 use hiqlite::{params, Param};
 use indoc::indoc;
 use tracing::warn;
@@ -32,11 +32,7 @@ pub async fn find_service_label_by_eid(deps: &impl Db, eid: Eid) -> DbResult<Opt
 
     Ok(deps
         .query_map_opt::<SvcLabel>(
-            format!(
-                "SELECT value FROM obj_text_attr WHERE obj_id = $1 AND prop_id = {prop_id}",
-                prop_id = PropId::from(BuiltinProp::Label).literal()
-            )
-            .into(),
+            "SELECT label FROM obj_label WHERE obj_id = $1".into(),
             params!(eid.as_param()),
         )
         .await
@@ -99,19 +95,16 @@ pub async fn get_service_property_mapping(
             deps.query_map(
                 indoc! {
                     "
-                    SELECT nslab.value ns, p.id pid, p.label plabel, a.id attrid, a.label alabel
+                    SELECT nslab.label ns, p.id pid, p.label plabel, a.id attrid, a.label alabel
                     FROM ns_ent_prop p
                     JOIN ns_ent_attrlabel a ON a.prop_id = p.id
                     JOIN svc_namespace ON svc_namespace.ns_id = p.ns_id
-                    JOIN obj_text_attr nslab ON nslab.obj_id = p.ns_id
-                    WHERE svc_namespace.svc_eid = $1 AND nslab.prop_id = $2
+                    JOIN obj_label nslab ON nslab.obj_id = p.ns_id
+                    WHERE svc_namespace.svc_eid = $1
                     ",
                 }
                 .into(),
-                params!(
-                    svc_eid.as_param(),
-                    PropId::from(BuiltinProp::Label).as_param()
-                ),
+                params!(svc_eid.as_param()),
             )
             .await?
         }
@@ -119,19 +112,16 @@ pub async fn get_service_property_mapping(
             deps.query_map(
                 indoc! {
                     "
-                    SELECT nslab.value ns, p.id pid, p.label plabel, a.id attrid, a.label alabel
+                    SELECT nslab.label ns, p.id pid, p.label plabel, a.id attrid, a.label alabel
                     FROM ns_res_prop p
                     JOIN ns_res_attrlabel a ON a.prop_id = p.id
                     JOIN svc_namespace ON svc_namespace.ns_id = p.ns_id
-                    JOIN obj_text_attr nslab ON nslab.obj_id = p.ns_id
-                    WHERE svc_namespace.svc_eid = $1 AND nslab.prop_id = $2
+                    JOIN obj_label nslab ON nslab.obj_id = p.ns_id
+                    WHERE svc_namespace.svc_eid = $1
                     ",
                 }
                 .into(),
-                params!(
-                    svc_eid.as_param(),
-                    PropId::from(BuiltinProp::Label).as_param()
-                ),
+                params!(svc_eid.as_param()),
             )
             .await?
         }

--- a/src/db/service_db.rs
+++ b/src/db/service_db.rs
@@ -1,16 +1,19 @@
-use authly_common::{id::ObjId, service::NamespacePropertyMapping};
+use authly_common::{
+    id::{AttrId, PropId},
+    service::NamespacePropertyMapping,
+};
 use authly_db::{literal::Literal, param::AsParam, Db, DbResult, FromRow, Row};
 use hiqlite::{params, Param};
 use indoc::indoc;
 use tracing::warn;
 
-use crate::{id::BuiltinID, Eid};
+use crate::{id::BuiltinProp, Eid};
 
 #[derive(Debug)]
 pub struct ServiceProperty {
-    pub id: ObjId,
+    pub id: PropId,
     pub label: String,
-    pub attributes: Vec<(ObjId, String)>,
+    pub attributes: Vec<(AttrId, String)>,
 }
 
 pub enum ServicePropertyKind {
@@ -31,7 +34,7 @@ pub async fn find_service_label_by_eid(deps: &impl Db, eid: Eid) -> DbResult<Opt
         .query_map_opt::<SvcLabel>(
             format!(
                 "SELECT value FROM obj_text_attr WHERE obj_id = $1 AND prop_id = {prop_id}",
-                prop_id = BuiltinID::PropLabel.to_obj_id().literal()
+                prop_id = PropId::from(BuiltinProp::Label).literal()
             )
             .into(),
             params!(eid.as_param()),
@@ -61,7 +64,7 @@ pub async fn find_service_eid_by_k8s_service_account_name(
         .query_map_opt::<SvcEid>(
             "SELECT obj_id FROM obj_text_attr WHERE prop_id = $1 AND value = $2".into(),
             params!(
-                BuiltinID::PropK8sServiceAccount.to_obj_id().as_param(),
+                PropId::from(BuiltinProp::K8sServiceAccount).as_param(),
                 format!("{namespace}/{account_name}")
             ),
         )
@@ -78,7 +81,7 @@ pub async fn get_service_property_mapping(
     svc_eid: Eid,
     property_kind: ServicePropertyKind,
 ) -> DbResult<NamespacePropertyMapping> {
-    struct TypedRow(String, String, String, ObjId);
+    struct TypedRow(String, String, String, AttrId);
 
     impl FromRow for TypedRow {
         fn from_row(row: &mut impl Row) -> Self {
@@ -96,18 +99,18 @@ pub async fn get_service_property_mapping(
             deps.query_map(
                 indoc! {
                     "
-                    SELECT ns.value ns, p.id pid, p.label plabel, a.id attrid, a.label alabel
-                    FROM dom_ent_prop p
-                    JOIN dom_ent_attrlabel a ON a.prop_id = p.id
-                    JOIN svc_domain ON svc_domain.dom_id = p.dom_id
-                    JOIN obj_text_attr ns ON ns.obj_id = p.dom_id
-                    WHERE svc_domain.svc_eid = $1 AND ns.prop_id = $2
+                    SELECT nslab.value ns, p.id pid, p.label plabel, a.id attrid, a.label alabel
+                    FROM ns_ent_prop p
+                    JOIN ns_ent_attrlabel a ON a.prop_id = p.id
+                    JOIN svc_namespace ON svc_namespace.ns_id = p.ns_id
+                    JOIN obj_text_attr nslab ON nslab.obj_id = p.ns_id
+                    WHERE svc_namespace.svc_eid = $1 AND nslab.prop_id = $2
                     ",
                 }
                 .into(),
                 params!(
                     svc_eid.as_param(),
-                    BuiltinID::PropLabel.to_obj_id().as_param()
+                    PropId::from(BuiltinProp::Label).as_param()
                 ),
             )
             .await?
@@ -116,18 +119,18 @@ pub async fn get_service_property_mapping(
             deps.query_map(
                 indoc! {
                     "
-                    SELECT ns.value ns, p.id pid, p.label plabel, a.id attrid, a.label alabel
-                    FROM dom_res_prop p
-                    JOIN dom_res_attrlabel a ON a.prop_id = p.id
-                    JOIN svc_domain ON svc_domain.dom_id = p.dom_id
-                    JOIN obj_text_attr ns ON ns.obj_id = p.dom_id
-                    WHERE svc_domain.svc_eid = $1 AND ns.prop_id = $2
+                    SELECT nslab.value ns, p.id pid, p.label plabel, a.id attrid, a.label alabel
+                    FROM ns_res_prop p
+                    JOIN ns_res_attrlabel a ON a.prop_id = p.id
+                    JOIN svc_namespace ON svc_namespace.ns_id = p.ns_id
+                    JOIN obj_text_attr nslab ON nslab.obj_id = p.ns_id
+                    WHERE svc_namespace.svc_eid = $1 AND nslab.prop_id = $2
                     ",
                 }
                 .into(),
                 params!(
                     svc_eid.as_param(),
-                    BuiltinID::PropLabel.to_obj_id().as_param()
+                    PropId::from(BuiltinProp::Label).as_param()
                 ),
             )
             .await?

--- a/src/db/settings_db.rs
+++ b/src/db/settings_db.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use authly_common::id::ObjId;
+use authly_common::id::DirectoryId;
 use authly_db::{Db, DbResult, Row, TryFromRow};
 use hiqlite::params;
 
@@ -8,7 +8,7 @@ use crate::settings::{Setting, Settings};
 
 struct LocalSetting {
     #[expect(unused)]
-    dir_id: ObjId,
+    dir_id: DirectoryId,
     setting: Setting,
     value: String,
 }

--- a/src/document/compiled_document.rs
+++ b/src/document/compiled_document.rs
@@ -3,12 +3,14 @@ use std::{
     ops::Range,
 };
 
-use authly_common::id::{AnyId, Eid, ObjId};
+use authly_common::id::{
+    AnyId, AttrId, DirectoryId, DomainId, Eid, PolicyBindingId, PolicyId, PropId,
+};
 use authly_db::DbError;
 
 use crate::{
     db::{policy_db, Identified},
-    id::BuiltinID,
+    id::BuiltinProp,
     policy::error::PolicyCompileErrorKind,
     settings::Setting,
 };
@@ -18,6 +20,7 @@ pub enum CompileError {
     LocalSettingNotFound,
     InvalidSettingValue(String),
     NameDefinedMultipleTimes(Range<usize>, String),
+    UnresolvedDomain,
     UnresolvedNamespace,
     UnresolvedEntity,
     UnresolvedProfile,
@@ -41,7 +44,7 @@ impl From<DbError> for CompileError {
 #[derive(Debug)]
 pub struct CompiledDocument {
     /// directory ID
-    pub dir_id: ObjId,
+    pub dir_id: DirectoryId,
     pub meta: DocumentMeta,
     pub data: CompiledDocumentData,
 }
@@ -65,24 +68,21 @@ pub struct CompiledDocumentData {
 
     pub service_ids: BTreeSet<Eid>,
 
-    // TODO: remove
-    pub domains: Vec<Identified<ObjId, String>>,
-
-    pub service_domains: Vec<(Eid, AnyId)>,
+    pub service_domains: Vec<(Eid, DomainId)>,
 
     pub entity_relations: Vec<CompiledEntityRelation>,
 
     pub domain_ent_props: Vec<CompiledProperty>,
     pub domain_res_props: Vec<CompiledProperty>,
 
-    pub policies: Vec<Identified<ObjId, policy_db::DbPolicy>>,
-    pub policy_bindings: Vec<Identified<ObjId, policy_db::DbPolicyBinding>>,
+    pub policies: Vec<Identified<PolicyId, policy_db::DbPolicy>>,
+    pub policy_bindings: Vec<Identified<PolicyBindingId, policy_db::DbPolicyBinding>>,
 }
 
 #[derive(Debug)]
 pub struct EntityIdent {
     pub eid: Eid,
-    pub prop_id: ObjId,
+    pub prop_id: PropId,
     pub ident: String,
 }
 
@@ -90,7 +90,7 @@ pub struct EntityIdent {
 #[derive(Debug)]
 pub struct ObjectTextAttr {
     pub obj_id: AnyId,
-    pub prop_id: ObjId,
+    pub prop_id: PropId,
     pub value: String,
 }
 
@@ -103,20 +103,20 @@ pub struct EntityPassword {
 #[derive(Debug)]
 pub struct CompiledEntityAttributeAssignment {
     pub eid: Eid,
-    pub attrid: ObjId,
+    pub attrid: AttrId,
 }
 
 #[derive(Debug)]
 pub struct CompiledEntityRelation {
     pub subject: Eid,
-    pub relation: ObjId,
+    pub relation: PropId,
     pub object: Eid,
 }
 
 #[derive(Debug)]
 pub struct CompiledProperty {
-    pub id: ObjId,
-    pub dom_id: AnyId,
+    pub id: PropId,
+    pub ns_id: AnyId,
     pub label: String,
 
     pub attributes: Vec<CompiledAttribute>,
@@ -124,7 +124,7 @@ pub struct CompiledProperty {
 
 #[derive(Debug)]
 pub struct CompiledAttribute {
-    pub id: ObjId,
+    pub id: AttrId,
     pub label: String,
 }
 
@@ -134,7 +134,7 @@ pub enum AttrLookupError {
 }
 
 impl CompiledDocumentData {
-    pub fn find_property(&self, prop_id: ObjId) -> Option<&CompiledProperty> {
+    pub fn find_property(&self, prop_id: PropId) -> Option<&CompiledProperty> {
         self.domain_ent_props
             .iter()
             .chain(self.domain_res_props.iter())
@@ -143,9 +143,9 @@ impl CompiledDocumentData {
 
     pub fn find_attribute_by_label(
         &self,
-        prop_id: ObjId,
+        prop_id: PropId,
         attr_label: &str,
-    ) -> Result<ObjId, AttrLookupError> {
+    ) -> Result<AttrId, AttrLookupError> {
         match self.find_property(prop_id) {
             Some(property) => property
                 .attributes
@@ -154,13 +154,13 @@ impl CompiledDocumentData {
                 .map(|attr| attr.id)
                 .ok_or(AttrLookupError::NoAttribute),
             None => {
-                if prop_id == BuiltinID::PropAuthlyRole.to_obj_id() {
-                    BuiltinID::PropAuthlyRole
+                if prop_id == PropId::from(BuiltinProp::AuthlyRole) {
+                    BuiltinProp::AuthlyRole
                         .attributes()
                         .iter()
                         .copied()
                         .find(|attr| attr.label() == Some(attr_label))
-                        .map(BuiltinID::to_obj_id)
+                        .map(AttrId::from)
                         .ok_or(AttrLookupError::NoAttribute)
                 } else {
                     Err(AttrLookupError::NoProperty)

--- a/src/document/compiled_document.rs
+++ b/src/document/compiled_document.rs
@@ -64,6 +64,7 @@ pub struct CompiledDocumentData {
 
     pub entity_ident: Vec<EntityIdent>,
     pub obj_text_attrs: Vec<ObjectTextAttr>,
+    pub obj_labels: Vec<ObjectLabel>,
     pub entity_password: Vec<EntityPassword>,
 
     pub service_ids: BTreeSet<Eid>,
@@ -86,12 +87,17 @@ pub struct EntityIdent {
     pub ident: String,
 }
 
-// note: This is not only for entities
 #[derive(Debug)]
 pub struct ObjectTextAttr {
     pub obj_id: AnyId,
     pub prop_id: PropId,
     pub value: String,
+}
+
+#[derive(Debug)]
+pub struct ObjectLabel {
+    pub obj_id: AnyId,
+    pub label: String,
 }
 
 #[derive(Debug)]

--- a/src/document/doc_compiler.rs
+++ b/src/document/doc_compiler.rs
@@ -16,7 +16,7 @@ use crate::db::directory_db::{DbDirectoryObjectLabel, DbDirectoryPolicy};
 use crate::db::policy_db::DbPolicy;
 use crate::db::{directory_db, policy_db, service_db, Identified};
 use crate::document::compiled_document::{
-    CompiledEntityAttributeAssignment, EntityIdent, ObjectTextAttr,
+    CompiledEntityAttributeAssignment, EntityIdent, ObjectLabel, ObjectTextAttr,
 };
 use crate::id::BuiltinProp;
 use crate::policy::compiler::PolicyCompiler;
@@ -166,10 +166,9 @@ pub async fn compile_doc(
 
             comp.ns_add(&domain.label, NamespaceKind::Domain(id));
 
-            data.obj_text_attrs.push(ObjectTextAttr {
+            data.obj_labels.push(ObjectLabel {
                 obj_id: id.into(),
-                prop_id: BuiltinProp::Label.into(),
-                value: domain.label.as_ref().to_string(),
+                label: domain.label.as_ref().to_string(),
             });
         }
     }
@@ -189,10 +188,9 @@ pub async fn compile_doc(
     for entity in &mut doc.service_entity {
         let eid = *entity.eid.as_ref();
         if let Some(label) = &entity.label {
-            data.obj_text_attrs.push(ObjectTextAttr {
+            data.obj_labels.push(ObjectLabel {
                 obj_id: eid.into(),
-                prop_id: BuiltinProp::Label.into(),
-                value: label.as_ref().to_string(),
+                label: label.as_ref().to_string(),
             });
         }
 

--- a/src/document/doc_compiler.rs
+++ b/src/document/doc_compiler.rs
@@ -3,26 +3,22 @@ use std::collections::hash_map::Entry;
 use std::{cmp, mem};
 use std::{collections::HashMap, ops::Range};
 
-use authly_common::id::AnyId;
+use authly_common::id::{AnyId, AttrId, DirectoryId, DomainId, PolicyBindingId, PolicyId, PropId};
 use authly_common::policy::code::PolicyValue;
-use authly_common::{
-    document,
-    id::{Eid, ObjId},
-    property::QualifiedAttributeName,
-};
+use authly_common::{document, id::Eid, property::QualifiedAttributeName};
 use authly_db::{Db, DbError};
 use serde::de::value::StrDeserializer;
 use serde::Deserialize;
 use serde_spanned::Spanned;
 use tracing::debug;
 
-use crate::db::directory_db::{DbDirectoryDomain, DbDirectoryPolicy};
+use crate::db::directory_db::{DbDirectoryObjectLabel, DbDirectoryPolicy};
 use crate::db::policy_db::DbPolicy;
 use crate::db::{directory_db, policy_db, service_db, Identified};
 use crate::document::compiled_document::{
     CompiledEntityAttributeAssignment, EntityIdent, ObjectTextAttr,
 };
-use crate::id::BuiltinID;
+use crate::id::BuiltinProp;
 use crate::policy::compiler::PolicyCompiler;
 use crate::settings::{Setting, Settings};
 use crate::util::error::{HandleError, ResultExt};
@@ -54,11 +50,11 @@ impl Namespaces {
         Ok(spanned.as_ref())
     }
 
-    fn insert_builtin_property(&mut self, builtin: BuiltinID) {
+    fn insert_builtin_property(&mut self, builtin: BuiltinProp) {
         let namespace = self.table.get_mut("authly").unwrap();
         namespace.as_mut().entries.insert(
             builtin.label().unwrap().to_string(),
-            Spanned::new(0..0, NamespaceEntry::PropertyLabel(builtin.to_obj_id())),
+            Spanned::new(0..0, NamespaceEntry::PropertyLabel(builtin.into())),
         );
     }
 }
@@ -79,27 +75,27 @@ pub enum NamespaceKind {
     Authly,
     Entity(Eid),
     Service(Eid),
-    Domain(ObjId),
-    Policy(ObjId),
+    Domain(DomainId),
+    Policy(PolicyId),
 }
 
 struct CompileCtx {
     /// Directory ID
-    dir_id: ObjId,
+    dir_id: DirectoryId,
 
     namespaces: Namespaces,
 
     eprop_cache: HashMap<AnyId, Vec<service_db::ServiceProperty>>,
     rprop_cache: HashMap<AnyId, Vec<service_db::ServiceProperty>>,
-    policy_cache: HashMap<ObjId, Vec<DbDirectoryPolicy>>,
-    domain_cache: Option<HashMap<String, ObjId>>,
+    policy_cache: HashMap<DirectoryId, Vec<DbDirectoryPolicy>>,
+    label_cache: Option<HashMap<String, AnyId>>,
 
     errors: Errors,
 }
 
 #[derive(Debug)]
 pub enum NamespaceEntry {
-    PropertyLabel(ObjId),
+    PropertyLabel(PropId),
 }
 
 #[derive(Default)]
@@ -113,12 +109,12 @@ pub async fn compile_doc(
     db: &impl Db,
 ) -> Result<CompiledDocument, Vec<Spanned<CompileError>>> {
     let mut comp = CompileCtx {
-        dir_id: ObjId::from_uint(doc.authly_document.id.get_ref().as_u128()),
+        dir_id: DirectoryId::from_uint(doc.authly_document.id.get_ref().as_u128()),
         namespaces: Default::default(),
         eprop_cache: Default::default(),
         rprop_cache: Default::default(),
         policy_cache: Default::default(),
-        domain_cache: Default::default(),
+        label_cache: Default::default(),
         errors: Default::default(),
     };
     let mut data = CompiledDocumentData {
@@ -158,23 +154,23 @@ pub async fn compile_doc(
         seed_namespace(&doc, &mut comp);
 
         for domain in mem::take(&mut doc.domain) {
-            let Some(cache) = comp.db_directory_domains_cache(db).await else {
+            let Some(cache) = comp.db_directory_object_labels_cached(db).await else {
                 continue;
             };
 
             let id = cache
                 .get(domain.label.as_ref())
                 .copied()
-                .unwrap_or_else(ObjId::random);
+                .and_then(|id| DomainId::try_from(id).ok())
+                .unwrap_or_else(DomainId::random);
 
             comp.ns_add(&domain.label, NamespaceKind::Domain(id));
 
             data.obj_text_attrs.push(ObjectTextAttr {
-                obj_id: AnyId::from_array(&id.to_bytes()),
-                prop_id: BuiltinID::PropLabel.to_obj_id(),
+                obj_id: id.into(),
+                prop_id: BuiltinProp::Label.into(),
                 value: domain.label.as_ref().to_string(),
             });
-            data.domains.push(Identified(id, domain.label.into_inner()));
         }
     }
 
@@ -184,7 +180,7 @@ pub async fn compile_doc(
         if let Some(username) = entity.username.take() {
             data.entity_ident.push(EntityIdent {
                 eid: *entity.eid.as_ref(),
-                prop_id: BuiltinID::PropUsername.to_obj_id(),
+                prop_id: BuiltinProp::Username.into(),
                 ident: username.into_inner(),
             });
         }
@@ -194,16 +190,16 @@ pub async fn compile_doc(
         let eid = *entity.eid.as_ref();
         if let Some(label) = &entity.label {
             data.obj_text_attrs.push(ObjectTextAttr {
-                obj_id: AnyId::from_array(&eid.to_bytes()),
-                prop_id: BuiltinID::PropLabel.to_obj_id(),
+                obj_id: eid.into(),
+                prop_id: BuiltinProp::Label.into(),
                 value: label.as_ref().to_string(),
             });
         }
 
         if let Some(k8s) = mem::take(&mut entity.kubernetes_account) {
             data.obj_text_attrs.push(ObjectTextAttr {
-                obj_id: AnyId::from_array(&eid.to_bytes()),
-                prop_id: BuiltinID::PropK8sServiceAccount.to_obj_id(),
+                obj_id: eid.into(),
+                prop_id: BuiltinProp::K8sServiceAccount.into(),
                 value: format!("{}/{}", k8s.namespace, k8s.name),
             });
         }
@@ -218,7 +214,7 @@ pub async fn compile_doc(
 
         data.entity_ident.push(EntityIdent {
             eid,
-            prop_id: BuiltinID::PropEmail.to_obj_id(),
+            prop_id: BuiltinProp::Email.into(),
             ident: email.value.into_inner(),
         });
     }
@@ -229,8 +225,8 @@ pub async fn compile_doc(
         };
 
         data.obj_text_attrs.push(ObjectTextAttr {
-            obj_id: AnyId::from_array(&eid.to_bytes()),
-            prop_id: BuiltinID::PropPasswordHash.to_obj_id(),
+            obj_id: eid.into(),
+            prop_id: BuiltinProp::PasswordHash.into(),
             value: hash.hash,
         });
     }
@@ -261,9 +257,17 @@ pub async fn compile_doc(
     for doc_svc_domain in doc.service_domain {
         if let (Some(svc_eid), Some(dom_id)) = (
             comp.ns_entity_lookup(&doc_svc_domain.service),
-            comp.ns_domain_lookup(&doc_svc_domain.domain),
+            comp.ns_dyn_namespace_lookup(&doc_svc_domain.domain),
         ) {
-            data.service_domains.push((svc_eid, dom_id));
+            match DomainId::try_from(dom_id) {
+                Ok(domain_id) => {
+                    data.service_domains.push((svc_eid, domain_id));
+                }
+                Err(_) => {
+                    comp.errors
+                        .push(doc_svc_domain.domain.span(), CompileError::UnresolvedDomain);
+                }
+            }
         }
     }
 
@@ -289,7 +293,7 @@ fn seed_namespace(doc: &document::Document, comp: &mut CompileCtx) {
             },
         ),
     );
-    for builtin_prop in [BuiltinID::PropEntity, BuiltinID::PropAuthlyRole] {
+    for builtin_prop in [BuiltinProp::Entity, BuiltinProp::AuthlyRole] {
         comp.namespaces.insert_builtin_property(builtin_prop);
     }
 
@@ -320,7 +324,7 @@ fn process_members(
             if let Some(member_eid) = comp.ns_entity_lookup(member) {
                 data.entity_relations.push(CompiledEntityRelation {
                     subject: subject_eid,
-                    relation: BuiltinID::RelEntityMembership.to_obj_id(),
+                    relation: BuiltinProp::RelEntityMembership.into(),
                     object: member_eid,
                 });
             };
@@ -389,13 +393,13 @@ async fn process_service_properties(
 ) {
     for doc_eprop in entity_properties {
         if let Some(domain_label) = &doc_eprop.domain {
-            let Some(svc_eid) = comp.ns_domain_lookup(domain_label) else {
+            let Some(ns_id) = comp.ns_dyn_namespace_lookup(domain_label) else {
                 continue;
             };
 
             if let Some(compiled_property) = compile_service_property(
                 domain_label,
-                svc_eid,
+                ns_id,
                 service_db::ServicePropertyKind::Entity,
                 &doc_eprop.label,
                 doc_eprop.attributes,
@@ -410,7 +414,7 @@ async fn process_service_properties(
     }
 
     for doc_rprop in resource_properties {
-        let Some(domain_eid) = comp.ns_domain_lookup(&doc_rprop.domain) else {
+        let Some(domain_eid) = comp.ns_dyn_namespace_lookup(&doc_rprop.domain) else {
             continue;
         };
 
@@ -432,7 +436,7 @@ async fn process_service_properties(
 
 async fn compile_service_property(
     svc_namespace: &Spanned<String>,
-    dom_id: AnyId,
+    ns_id: AnyId,
     property_kind: service_db::ServicePropertyKind,
     doc_property_label: &Spanned<String>,
     doc_attributes: Vec<Spanned<String>>,
@@ -440,7 +444,7 @@ async fn compile_service_property(
     db: &impl Db,
 ) -> Option<CompiledProperty> {
     let db_props_cached = comp
-        .db_domain_properties_cached(dom_id, property_kind, db)
+        .db_namespace_properties_cached(ns_id, property_kind, db)
         .await?;
 
     let db_eprop = db_props_cached
@@ -451,8 +455,8 @@ async fn compile_service_property(
         id: db_eprop
             .as_ref()
             .map(|db_prop| db_prop.id)
-            .unwrap_or_else(ObjId::random),
-        dom_id,
+            .unwrap_or_else(PropId::random),
+        ns_id,
         label: doc_property_label.as_ref().to_string(),
         attributes: vec![],
     };
@@ -469,7 +473,7 @@ async fn compile_service_property(
             id: db_attr
                 .as_ref()
                 .map(|attr| attr.0)
-                .unwrap_or_else(ObjId::random),
+                .unwrap_or_else(AttrId::random),
             label: doc_attribute.into_inner(),
         });
     }
@@ -578,24 +582,24 @@ async fn process_policies(
         let namespace_label = policy.label.as_ref().to_string();
         let label_span = policy.label.span();
 
-        let service_policy: Identified<ObjId, DbPolicy> = if let Some(cached_policy) = cached_policy
-        {
-            Identified(
-                cached_policy.id,
-                policy_db::DbPolicy {
-                    label: policy.label.into_inner(),
-                    policy: policy_postcard,
-                },
-            )
-        } else {
-            Identified(
-                ObjId::random(),
-                policy_db::DbPolicy {
-                    label: policy.label.into_inner(),
-                    policy: policy_postcard,
-                },
-            )
-        };
+        let service_policy: Identified<PolicyId, DbPolicy> =
+            if let Some(cached_policy) = cached_policy {
+                Identified(
+                    cached_policy.id,
+                    policy_db::DbPolicy {
+                        label: policy.label.into_inner(),
+                        policy: policy_postcard,
+                    },
+                )
+            } else {
+                Identified(
+                    PolicyId::random(),
+                    policy_db::DbPolicy {
+                        label: policy.label.into_inner(),
+                        policy: policy_postcard,
+                    },
+                )
+            };
 
         comp.namespaces.table.insert(
             namespace_label,
@@ -619,7 +623,7 @@ fn process_policy_bindings(
 ) {
     for binding in policy_bindings {
         let mut policy_binding = Identified(
-            ObjId::random(),
+            PolicyBindingId::random(),
             policy_db::DbPolicyBinding {
                 attr_matcher: Default::default(),
                 policies: Default::default(),
@@ -724,10 +728,10 @@ impl CompileCtx {
         }
     }
 
-    fn ns_domain_lookup(&mut self, key: &Spanned<impl AsRef<str>>) -> Option<AnyId> {
+    fn ns_dyn_namespace_lookup(&mut self, key: &Spanned<impl AsRef<str>>) -> Option<AnyId> {
         match self.ns_lookup_kind(key, CompileError::UnresolvedService)? {
-            NamespaceKind::Service(eid) => Some(AnyId::from_array(&eid.to_bytes())),
-            NamespaceKind::Domain(dom_id) => Some(AnyId::from_array(&dom_id.to_bytes())),
+            NamespaceKind::Service(eid) => Some((*eid).into()),
+            NamespaceKind::Domain(dom_id) => Some((*dom_id).into()),
             _ => {
                 self.errors
                     .push(key.span(), CompileError::UnresolvedService);
@@ -740,15 +744,15 @@ impl CompileCtx {
         &mut self,
         namespace: &Spanned<impl AsRef<str>>,
         key: &Spanned<impl AsRef<str>>,
-    ) -> Option<ObjId> {
+    ) -> Option<PropId> {
         match self.ns_lookup_entry(namespace, key, CompileError::UnresolvedProperty)? {
-            NamespaceEntry::PropertyLabel(obj_id) => Some(*obj_id),
+            NamespaceEntry::PropertyLabel(prop_id) => Some(*prop_id),
         }
     }
 
-    fn ns_policy_lookup(&mut self, key: &Spanned<impl AsRef<str>>) -> Option<ObjId> {
+    fn ns_policy_lookup(&mut self, key: &Spanned<impl AsRef<str>>) -> Option<PolicyId> {
         match self.ns_lookup_kind(key, CompileError::UnresolvedProperty)? {
-            NamespaceKind::Policy(obj_id) => Some(*obj_id),
+            NamespaceKind::Policy(policy_id) => Some(*policy_id),
             _ => {
                 self.errors.push(key.span(), CompileError::UnresolvedPolicy);
                 None
@@ -793,9 +797,9 @@ impl CompileCtx {
         }
     }
 
-    async fn db_domain_properties_cached<'s>(
+    async fn db_namespace_properties_cached<'s>(
         &'s mut self,
-        dom_id: AnyId,
+        ns_id: AnyId,
         property_kind: service_db::ServicePropertyKind,
         db: &impl Db,
     ) -> Option<&'s Vec<service_db::ServiceProperty>> {
@@ -804,11 +808,11 @@ impl CompileCtx {
             service_db::ServicePropertyKind::Resource => &mut self.rprop_cache,
         };
 
-        match cache.entry(dom_id) {
+        match cache.entry(ns_id) {
             Entry::Occupied(occupied) => Some(occupied.into_mut()),
             Entry::Vacant(vacant) => {
                 let db_props =
-                    directory_db::list_domain_properties(db, self.dir_id, dom_id, property_kind)
+                    directory_db::list_namespace_properties(db, self.dir_id, ns_id, property_kind)
                         .await
                         .handle_err(&mut self.errors)?;
                 Some(vacant.insert(db_props))
@@ -834,22 +838,22 @@ impl CompileCtx {
         }
     }
 
-    async fn db_directory_domains_cache<'s>(
+    async fn db_directory_object_labels_cached<'s>(
         &'s mut self,
         db: &impl Db,
-    ) -> Option<&'s HashMap<String, ObjId>> {
-        if self.domain_cache.is_some() {
-            Some(self.domain_cache.as_mut().unwrap())
+    ) -> Option<&'s HashMap<String, AnyId>> {
+        if self.label_cache.is_some() {
+            Some(self.label_cache.as_mut().unwrap())
         } else {
-            let db_domains = DbDirectoryDomain::query(db, self.dir_id)
+            let db_domains = DbDirectoryObjectLabel::query(db, self.dir_id)
                 .await
                 .handle_err(&mut self.errors)?;
 
             Some(
-                self.domain_cache.insert(
+                self.label_cache.insert(
                     db_domains
                         .into_iter()
-                        .map(|DbDirectoryDomain { id, label }| (label, id))
+                        .map(|DbDirectoryObjectLabel { id, label }| (label, id))
                         .collect(),
                 ),
             )

--- a/src/document/load.rs
+++ b/src/document/load.rs
@@ -1,7 +1,7 @@
 use std::{fs, os::unix::ffi::OsStrExt};
 
 use anyhow::anyhow;
-use authly_common::{document::Document, id::ObjId};
+use authly_common::{document::Document, id::DirectoryId};
 use tracing::info;
 
 use crate::{
@@ -52,7 +52,7 @@ pub(crate) async fn load_cfg_documents(
                 },
             };
 
-            let dir_id = ObjId::from_uint(document.authly_document.id.get_ref().as_u128());
+            let dir_id = DirectoryId::from_uint(document.authly_document.id.get_ref().as_u128());
 
             if should_process(dir_id, &meta, &doc_authorities) {
                 info!(?path, "load");
@@ -78,7 +78,7 @@ pub(crate) async fn load_cfg_documents(
 }
 
 fn should_process(
-    dir_id: ObjId,
+    dir_id: DirectoryId,
     meta: &DocumentMeta,
     doc_directories: &[DocumentDirectory],
 ) -> bool {

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,47 +1,58 @@
-use authly_common::id::{Id128, ObjId};
+use authly_common::id::{AttrId, PropId};
 use int_enum::IntEnum;
 
-/// Builtin Object IDs
 #[derive(Clone, Copy, Eq, PartialEq, Hash, IntEnum, Debug)]
 #[repr(u32)]
-pub enum BuiltinID {
-    /// Id representing Authly itself
-    Authly = 0,
-    /// The entity property
-    PropEntity = 1,
-    /// The built-in authly:role for authly internal access control
-    PropAuthlyRole = 2,
-    /// A service role for getting an access token
-    AttrAuthlyRoleGetAccessToken = 3,
-    /// A service role for authenticating users
-    AttrAuthlyRoleAuthenticate = 4,
-    /// A user role for applying documents
-    AttrAuthlyRoleApplyDocument = 5,
-    /// The entity membership relation
-    RelEntityMembership = 6,
-    /// The username ident property
-    PropUsername = 7,
-    /// The email ident property
-    PropEmail = 8,
-    /// The password_hash text property
-    PropPasswordHash = 9,
-    /// The label text property
-    PropLabel = 10,
-    /// The kubernetes service account name property.
-    /// The value format is `{namespace}/{account_name}`.
-    PropK8sServiceAccount = 11,
-    /// The Authly instance property
-    PropAuthlyInstance = 12,
-    /// A user role for granting mandates to authority
-    AttrAuthlyRoleGrantMandate = 13,
+pub enum BuiltinEntity {
+    /// Entity referring to the local Authly instance
+    LocalAuthly = 0,
 }
 
-impl BuiltinID {
-    /// Convert to an [ObjId].
-    pub const fn to_obj_id(self) -> ObjId {
-        Id128::from_uint(self as u128)
-    }
+#[derive(Clone, Copy, Eq, PartialEq, Hash, IntEnum, Debug)]
+#[repr(u32)]
+pub enum BuiltinProp {
+    /// The entity property
+    Entity = 0,
+    /// The built-in authly:role for authly internal access control
+    AuthlyRole = 1,
+    /// The Authly instance property
+    AuthlyInstance = 2,
+    /// The username ident property
+    Username = 3,
+    /// The email ident property
+    Email = 4,
+    /// The password_hash text property
+    PasswordHash = 5,
+    /// The label text property
+    Label = 6,
+    /// The kubernetes service account name property.
+    /// The value format is `{namespace}/{account_name}`.
+    K8sServiceAccount = 7,
+    /// A relation property representing "membership" relation
+    RelEntityMembership = 8,
+}
 
+#[expect(clippy::enum_variant_names)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, IntEnum, Debug)]
+#[repr(u32)]
+pub enum BuiltinAttr {
+    /// A service role for getting an access token
+    AuthlyRoleGetAccessToken = 0,
+    /// A service role for authenticating users
+    AuthlyRoleAuthenticate = 1,
+    /// A user role for applying documents
+    AuthlyRoleApplyDocument = 2,
+    /// A user role for granting mandates to authority
+    AuthlyRoleGrantMandate = 3,
+}
+
+impl From<BuiltinProp> for PropId {
+    fn from(value: BuiltinProp) -> PropId {
+        PropId::from_uint(value as u128)
+    }
+}
+
+impl BuiltinProp {
     pub fn iter() -> impl Iterator<Item = Self> {
         (0..u32::MAX)
             .map(Self::try_from)
@@ -51,53 +62,55 @@ impl BuiltinID {
     /// Get an optional label for this builtin ID.
     pub const fn label(self) -> Option<&'static str> {
         match self {
-            Self::Authly => None,
-            Self::PropEntity => Some("entity"),
-            Self::PropAuthlyRole => Some("role"),
-            Self::AttrAuthlyRoleGetAccessToken => Some("get_access_token"),
-            Self::AttrAuthlyRoleAuthenticate => Some("authenticate"),
-            Self::AttrAuthlyRoleApplyDocument => Some("apply_document"),
-            Self::PropUsername => None,
-            Self::PropEmail => None,
+            Self::Entity => Some("entity"),
+            Self::AuthlyRole => Some("role"),
+            Self::Username => None,
+            Self::Email => None,
+            Self::PasswordHash => None,
+            Self::Label => None,
+            Self::K8sServiceAccount => None,
+            Self::AuthlyInstance => None,
             Self::RelEntityMembership => None,
-            Self::PropPasswordHash => None,
-            Self::PropLabel => None,
-            Self::PropK8sServiceAccount => None,
-            Self::PropAuthlyInstance => None,
-            Self::AttrAuthlyRoleGrantMandate => Some("grant_mandate"),
         }
     }
 
-    /// Whether the property is encrypted
-    pub const fn is_encrypted_prop(self) -> bool {
+    pub const fn is_encrypted(self) -> bool {
         match self {
-            Self::Authly
-            | Self::PropEntity
-            | Self::PropAuthlyRole
-            | Self::AttrAuthlyRoleGetAccessToken
-            | Self::AttrAuthlyRoleAuthenticate
-            | Self::AttrAuthlyRoleApplyDocument
-            | Self::AttrAuthlyRoleGrantMandate
-            | Self::RelEntityMembership => false,
-            Self::PropUsername => true,
-            Self::PropEmail => true,
-            Self::PropPasswordHash => true,
-            Self::PropLabel => false,
-            Self::PropK8sServiceAccount => true,
-            Self::PropAuthlyInstance => true,
+            Self::Entity | Self::AuthlyRole | Self::Label | Self::RelEntityMembership => false,
+            Self::Username => true,
+            Self::Email => true,
+            Self::PasswordHash => false,
+            Self::K8sServiceAccount => true,
+            Self::AuthlyInstance => true,
         }
     }
 
-    /// List attributes for an ID, in case it represents a builtin-in property.
-    pub const fn attributes(self) -> &'static [BuiltinID] {
+    pub const fn attributes(self) -> &'static [BuiltinAttr] {
         match self {
-            Self::PropAuthlyRole => &[
-                Self::AttrAuthlyRoleGetAccessToken,
-                Self::AttrAuthlyRoleAuthenticate,
-                Self::AttrAuthlyRoleApplyDocument,
-                Self::AttrAuthlyRoleGrantMandate,
+            Self::AuthlyRole => &[
+                BuiltinAttr::AuthlyRoleGetAccessToken,
+                BuiltinAttr::AuthlyRoleAuthenticate,
+                BuiltinAttr::AuthlyRoleApplyDocument,
+                BuiltinAttr::AuthlyRoleGrantMandate,
             ],
             _ => &[],
+        }
+    }
+}
+
+impl From<BuiltinAttr> for AttrId {
+    fn from(value: BuiltinAttr) -> AttrId {
+        AttrId::from_uint(value as u128)
+    }
+}
+
+impl BuiltinAttr {
+    pub const fn label(self) -> Option<&'static str> {
+        match self {
+            Self::AuthlyRoleGetAccessToken => Some("get_access_token"),
+            Self::AuthlyRoleAuthenticate => Some("authenticate"),
+            Self::AuthlyRoleApplyDocument => Some("apply_document"),
+            Self::AuthlyRoleGrantMandate => Some("grant_mandate"),
         }
     }
 }

--- a/src/id.rs
+++ b/src/id.rs
@@ -23,13 +23,11 @@ pub enum BuiltinProp {
     Email = 4,
     /// The password_hash text property
     PasswordHash = 5,
-    /// The label text property
-    Label = 6,
     /// The kubernetes service account name property.
     /// The value format is `{namespace}/{account_name}`.
-    K8sServiceAccount = 7,
+    K8sServiceAccount = 6,
     /// A relation property representing "membership" relation
-    RelEntityMembership = 8,
+    RelEntityMembership = 7,
 }
 
 #[expect(clippy::enum_variant_names)]
@@ -67,7 +65,6 @@ impl BuiltinProp {
             Self::Username => None,
             Self::Email => None,
             Self::PasswordHash => None,
-            Self::Label => None,
             Self::K8sServiceAccount => None,
             Self::AuthlyInstance => None,
             Self::RelEntityMembership => None,
@@ -76,7 +73,7 @@ impl BuiltinProp {
 
     pub const fn is_encrypted(self) -> bool {
         match self {
-            Self::Entity | Self::AuthlyRole | Self::Label | Self::RelEntityMembership => false,
+            Self::Entity | Self::AuthlyRole | Self::RelEntityMembership => false,
             Self::Username => true,
             Self::Email => true,
             Self::PasswordHash => false,

--- a/src/openapi/user_auth.rs
+++ b/src/openapi/user_auth.rs
@@ -13,7 +13,7 @@ use crate::{
         entity_db::{self, EntityPasswordHash},
         session_db,
     },
-    id::BuiltinID,
+    id::{BuiltinAttr, BuiltinProp},
     session::{new_session_cookie, Session, SessionToken, SESSION_TTL},
     AuthlyCtx, Eid,
 };
@@ -79,7 +79,7 @@ pub async fn authenticate(
     Extension(PeerServiceEntity(peer_svc_eid)): Extension<PeerServiceEntity>,
     Json(body): Json<AuthenticateRequest>,
 ) -> Result<axum::response::Response, AuthError> {
-    authorize_peer_service(peer_svc_eid, &[BuiltinID::AttrAuthlyRoleAuthenticate], &ctx).await?;
+    authorize_peer_service(peer_svc_eid, &[BuiltinAttr::AuthlyRoleAuthenticate], &ctx).await?;
 
     // BUG: figure this out:
     let _mfa_needed = false;
@@ -87,7 +87,7 @@ pub async fn authenticate(
 
     let (ehash, secret) = match body {
         AuthenticateRequest::User { username, password } => {
-            let prop_id = BuiltinID::PropUsername.to_obj_id();
+            let prop_id = BuiltinProp::Username.into();
 
             let ident_fingerprint = {
                 let deks = ctx.deks.load_full();
@@ -98,7 +98,7 @@ pub async fn authenticate(
 
             let ehash = entity_db::find_local_directory_entity_password_hash_by_entity_ident(
                 ctx.get_db(),
-                BuiltinID::PropUsername.to_obj_id(),
+                BuiltinProp::Username.into(),
                 &ident_fingerprint,
             )
             .await?

--- a/src/policy/compiler/codegen.rs
+++ b/src/policy/compiler/codegen.rs
@@ -1,6 +1,9 @@
-use authly_common::{id::AnyId, policy::code::OpCode};
+use authly_common::{
+    id::{AttrId, Eid, PropId},
+    policy::code::OpCode,
+};
 
-use crate::id::BuiltinID;
+use crate::id::BuiltinProp;
 
 use super::expr::{Expr, Global, Term};
 
@@ -55,12 +58,12 @@ impl Codegen {
         match term {
             Term::Label(label) => self
                 .ops
-                .push(OpCode::LoadConstId(AnyId::from(label.0).to_uint())),
+                .push(OpCode::LoadConstEntityId(Eid::from(label.0).to_uint())),
             Term::Field(global, label) => match global {
                 Global::Subject => {
-                    if label.0 == BuiltinID::PropEntity.to_obj_id().to_bytes() {
+                    if label.0 == PropId::from(BuiltinProp::Entity).to_raw_array() {
                         self.ops.push(OpCode::LoadSubjectId(
-                            BuiltinID::PropEntity.to_obj_id().to_uint(),
+                            PropId::from(BuiltinProp::Entity).to_uint(),
                         ));
                     } else {
                         self.ops.push(OpCode::LoadSubjectAttrs);
@@ -72,7 +75,7 @@ impl Codegen {
             },
             Term::Attr(_prop, attr) => self
                 .ops
-                .push(OpCode::LoadConstId(AnyId::from(attr.0).to_uint())),
+                .push(OpCode::LoadConstAttrId(AttrId::from(attr.0).to_uint())),
             Term::Error => {}
         }
     }

--- a/src/policy/compiler/parse_check.rs
+++ b/src/policy/compiler/parse_check.rs
@@ -92,7 +92,7 @@ impl PolicyCompiler<'_> {
                     .doc_data
                     .find_attribute_by_label(property_label.0.into(), attr_label_str)
                 {
-                    Ok(id) => Label(id.to_bytes()),
+                    Ok(id) => Label(id.to_raw_array()),
                     Err(_) => {
                         self.pest_error(
                             span,
@@ -124,8 +124,8 @@ impl PolicyCompiler<'_> {
         };
 
         match &namespace.kind {
-            NamespaceKind::Entity(id) => Some(Label(id.to_bytes())),
-            NamespaceKind::Service(id) => Some(Label(id.to_bytes())),
+            NamespaceKind::Entity(id) => Some(Label(id.to_raw_array())),
+            NamespaceKind::Service(id) => Some(Label(id.to_raw_array())),
             _ => {
                 self.pest_error(
                     pair.as_span(),
@@ -140,7 +140,7 @@ impl PolicyCompiler<'_> {
         let ns_label = namespace.as_str();
         let prop_label = prop.as_str();
         match self.namespace.get_entry(ns_label, prop_label) {
-            Ok(NamespaceEntry::PropertyLabel(id)) => Some(Label(id.to_bytes())),
+            Ok(NamespaceEntry::PropertyLabel(id)) => Some(Label(id.to_raw_array())),
             Err(NsLookupErr::Namespace) => {
                 self.pest_error(
                     namespace.as_span(),

--- a/src/policy/test_compile.rs
+++ b/src/policy/test_compile.rs
@@ -3,7 +3,7 @@ use super::compiler::{
     PolicyCompiler,
 };
 use authly_common::{
-    id::{AnyId, Eid, ObjId},
+    id::{AttrId, Eid, PropId},
     policy::code::OpCode,
 };
 
@@ -12,12 +12,12 @@ use crate::{
         compiled_document::{CompiledAttribute, CompiledDocumentData, CompiledProperty},
         doc_compiler::{NamespaceEntry, NamespaceKind, Namespaces},
     },
-    id::BuiltinID,
+    id::BuiltinProp,
 };
 
 const SVC: Eid = Eid::from_uint(42);
-const ROLE: ObjId = ObjId::from_uint(1337);
-const ROLE_ROOT: ObjId = ObjId::from_uint(1338);
+const ROLE: PropId = PropId::from_uint(1337);
+const ROLE_ROOT: AttrId = AttrId::from_uint(1338);
 
 fn test_env() -> (Namespaces, CompiledDocumentData) {
     let namespace = Namespaces::from_iter([
@@ -26,7 +26,7 @@ fn test_env() -> (Namespaces, CompiledDocumentData) {
             NamespaceKind::Service(SVC),
             vec![(
                 "entity".to_string(),
-                NamespaceEntry::PropertyLabel(BuiltinID::PropEntity.to_obj_id()),
+                NamespaceEntry::PropertyLabel(BuiltinProp::Entity.into()),
             )],
         ),
         (
@@ -38,7 +38,7 @@ fn test_env() -> (Namespaces, CompiledDocumentData) {
     let mut doc_data = CompiledDocumentData::default();
     doc_data.domain_ent_props.push(CompiledProperty {
         id: ROLE,
-        dom_id: AnyId::from_array(&SVC.to_bytes()),
+        ns_id: SVC.into(),
         label: "role".to_string(),
         attributes: vec![CompiledAttribute {
             id: ROLE_ROOT,
@@ -71,9 +71,9 @@ fn subject_entity_equals_svc() -> Expr {
     Expr::Equals(
         Term::Field(
             Global::Subject,
-            Label(BuiltinID::PropEntity.to_obj_id().to_bytes()),
+            Label(PropId::from(BuiltinProp::Entity).to_raw_array()),
         ),
-        Term::Label(Label(SVC.to_bytes())),
+        Term::Label(Label(SVC.to_raw_array())),
     )
 }
 
@@ -89,8 +89,8 @@ fn test_expr_equals() {
 fn test_expr_field_attribute() {
     assert_eq!(
         Expr::Contains(
-            Term::Field(Global::Subject, Label(ROLE.to_bytes())),
-            Term::Attr(Label(ROLE.to_bytes()), Label(ROLE_ROOT.to_bytes()))
+            Term::Field(Global::Subject, Label(ROLE.to_raw_array())),
+            Term::Attr(Label(ROLE.to_raw_array()), Label(ROLE_ROOT.to_raw_array()))
         ),
         to_expr("Subject.svc:role contains svc:role:root")
     );
@@ -141,15 +141,15 @@ fn test_expr_logical_paren() {
 fn test_opcodes() {
     assert_eq!(
         vec![
-            OpCode::LoadSubjectId(BuiltinID::PropEntity.to_obj_id().to_uint()),
-            OpCode::LoadConstId(SVC.to_uint()),
+            OpCode::LoadSubjectId(PropId::from(BuiltinProp::Entity).to_uint()),
+            OpCode::LoadConstEntityId(SVC.to_uint()),
             OpCode::IsEq,
-            OpCode::LoadSubjectId(BuiltinID::PropEntity.to_obj_id().to_uint()),
-            OpCode::LoadConstId(SVC.to_uint()),
+            OpCode::LoadSubjectId(PropId::from(BuiltinProp::Entity).to_uint()),
+            OpCode::LoadConstEntityId(SVC.to_uint()),
             OpCode::IsEq,
             OpCode::And,
-            OpCode::LoadSubjectId(BuiltinID::PropEntity.to_obj_id().to_uint()),
-            OpCode::LoadConstId(SVC.to_uint()),
+            OpCode::LoadSubjectId(PropId::from(BuiltinProp::Entity).to_uint()),
+            OpCode::LoadConstEntityId(SVC.to_uint()),
             OpCode::IsEq,
             OpCode::Or,
             OpCode::Return,

--- a/src/proto/mandate_submission.rs
+++ b/src/proto/mandate_submission.rs
@@ -51,25 +51,25 @@ where
 
         // cert chain, start with Mandate's new local CA
         let mut ca_chain = vec![proto::AuthlyCertificate {
-            certifies_entity_id: certified_mandate.mandate_eid.to_bytes().to_vec(),
-            signed_by_entity_id: instance.authly_eid().to_bytes().to_vec(),
+            certifies_entity_id: certified_mandate.mandate_eid.to_raw_array().to_vec(),
+            signed_by_entity_id: instance.authly_eid().to_raw_array().to_vec(),
             der: certified_mandate.mandate_local_ca.der.to_vec(),
         }];
 
         // pass authority's local CA chain to the mandate
         for authly_cert in instance.ca_chain() {
             ca_chain.push(proto::AuthlyCertificate {
-                certifies_entity_id: authly_cert.certifies.to_bytes().to_vec(),
-                signed_by_entity_id: authly_cert.signed_by.to_bytes().to_vec(),
+                certifies_entity_id: authly_cert.certifies.to_raw_array().to_vec(),
+                signed_by_entity_id: authly_cert.signed_by.to_raw_array().to_vec(),
                 der: authly_cert.der.to_vec(),
             });
         }
 
         Ok(tonic::Response::new(proto::SubmissionResponse {
-            mandate_entity_id: certified_mandate.mandate_eid.to_bytes().to_vec(),
+            mandate_entity_id: certified_mandate.mandate_eid.to_raw_array().to_vec(),
             mandate_identity_cert: Some(proto::AuthlyCertificate {
-                certifies_entity_id: certified_mandate.mandate_eid.to_bytes().to_vec(),
-                signed_by_entity_id: instance.authly_eid().to_bytes().to_vec(),
+                certifies_entity_id: certified_mandate.mandate_eid.to_raw_array().to_vec(),
+                signed_by_entity_id: instance.authly_eid().to_raw_array().to_vec(),
                 der: certified_mandate.mandate_identity.der.to_vec(),
             }),
             ca_chain,

--- a/src/tests/end2end/mod.rs
+++ b/src/tests/end2end/mod.rs
@@ -12,7 +12,7 @@ impl ConnectionBuilder {
                 .with_url("https://localhost:1443")
                 .with_authly_local_ca_pem(std::fs::read(".local/etc/certs/local.crt")?)?
                 .with_identity(authly_client::identity::Identity::from_pem(std::fs::read(
-                    ".local/etc/service/f3e799137c034e1eb4cd3e4f65705932/identity.pem",
+                    ".local/etc/service/e.f3e799137c034e1eb4cd3e4f65705932/identity.pem",
                 )?)?),
         ))
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -52,6 +52,8 @@ async fn compile_and_apply_doc(
 
             anyhow!("doc compile error)")
         })?;
+
+    // TODO: Improve testing by transacting the same document twice
     for (idx, result) in ctx
         .get_db()
         .transact(document_db::document_txn_statements(compiled_doc, deks)?)

--- a/src/tests/test_access_control.rs
+++ b/src/tests/test_access_control.rs
@@ -1,5 +1,5 @@
 use authly_common::{
-    id::{AnyId, Eid},
+    id::{AttrId, Eid},
     policy::{
         code::PolicyValue,
         engine::{AccessControlParams, NoOpPolicyTracer},
@@ -15,8 +15,8 @@ use crate::{
     tests::{compile_and_apply_doc, ServiceProperties},
 };
 
-const SVC_A: Eid = Eid::from_array(hex_literal!("e5462a0d22b54d9f9ca37bd96e9b9d8b"));
-const SVC_B: Eid = Eid::from_array(hex_literal!("015362d6655447c6b7f44865bd111c70"));
+const SVC_A: Eid = Eid::from_raw_array(hex_literal!("e5462a0d22b54d9f9ca37bd96e9b9d8b"));
+const SVC_B: Eid = Eid::from_raw_array(hex_literal!("015362d6655447c6b7f44865bd111c70"));
 
 #[test_log::test(tokio::test)]
 async fn test_access_control_basic() {
@@ -27,11 +27,11 @@ async fn test_access_control_basic() {
         id = "bc9ce588-50c3-47d1-94c1-f88b21eaf299"
 
         [[service-entity]]
-        eid = "e5462a0d22b54d9f9ca37bd96e9b9d8b"
+        eid = "e.e5462a0d22b54d9f9ca37bd96e9b9d8b"
         label = "svc_a"
 
         [[service-entity]]
-        eid = "015362d6655447c6b7f44865bd111c70"
+        eid = "e.015362d6655447c6b7f44865bd111c70"
         label = "svc_b"
 
         [[entity-property]]
@@ -92,7 +92,7 @@ async fn test_access_control_basic() {
             engine
                 .eval(
                     &AccessControlParams {
-                        resource_attrs: FromIterator::from_iter([AnyId::from_uint(42)]),
+                        resource_attrs: FromIterator::from_iter([AttrId::from_uint(42)]),
                         ..Default::default()
                     },
                     &mut NoOpPolicyTracer
@@ -175,11 +175,11 @@ async fn test_svc_domain_implied_policies() {
         label = "bar"
 
         [[service-entity]]
-        eid = "e5462a0d22b54d9f9ca37bd96e9b9d8b"
+        eid = "e.e5462a0d22b54d9f9ca37bd96e9b9d8b"
         label = "svc_a"
 
         [[service-entity]]
-        eid = "015362d6655447c6b7f44865bd111c70"
+        eid = "e.015362d6655447c6b7f44865bd111c70"
         label = "svc_b"
 
         [[service-domain]]

--- a/src/tests/test_authly_connect.rs
+++ b/src/tests/test_authly_connect.rs
@@ -36,7 +36,7 @@ async fn test_connect_grpc() {
     let tunneled_server_cert =
         ca.sign(server_cert("authly-connect", Duration::hours(1)).with_new_key_pair());
     let client_cert = ca.sign(
-        client_cert("cf2e74c3f26240908e1b4e8817bfde7c", Duration::hours(1)).with_new_key_pair(),
+        client_cert("e.cf2e74c3f26240908e1b4e8817bfde7c", Duration::hours(1)).with_new_key_pair(),
     );
 
     let (local_url, _drop) = spawn_test_connect_server(
@@ -148,7 +148,7 @@ async fn test_connect_http() {
     let tunneled_server_cert =
         ca.sign(server_cert("authly-connect", Duration::hours(1)).with_new_key_pair());
     let client_cert = ca.sign(
-        client_cert("cf2e74c3f26240908e1b4e8817bfde7c", Duration::hours(1)).with_new_key_pair(),
+        client_cert("e.cf2e74c3f26240908e1b4e8817bfde7c", Duration::hours(1)).with_new_key_pair(),
     );
     let (local_url, _drop) = spawn_test_connect_server(
         rustls_server_config_mtls(&[&tunneled_server_cert], &ca.der).unwrap(),
@@ -212,5 +212,5 @@ async fn test_connect_http() {
 
     info!("response: {response}");
 
-    assert!(response.ends_with("HELLO cf2e74c3f26240908e1b4e8817bfde7c!"));
+    assert!(response.ends_with("HELLO e.cf2e74c3f26240908e1b4e8817bfde7c!"));
 }

--- a/src/tests/test_document.rs
+++ b/src/tests/test_document.rs
@@ -17,13 +17,13 @@ async fn test_store_doc_trivial() {
         id = "bc9ce588-50c3-47d1-94c1-f88b21eaf299"
 
         [[service-entity]]
-        eid = "e5462a0d22b54d9f9ca37bd96e9b9d8b"
+        eid = "e.e5462a0d22b54d9f9ca37bd96e9b9d8b"
         label = "service1"
         attributes = ["authly:role:authenticate", "authly:role:get_access_token"]
         kubernetes-account = { name = "testservice", namespace = "authly-test" }
 
         [[service-entity]]
-        eid = "015362d6655447c6b7f44865bd111c70"
+        eid = "e.015362d6655447c6b7f44865bd111c70"
         label = "service2"
         "#
     };

--- a/src/tests/test_tls.rs
+++ b/src/tests/test_tls.rs
@@ -144,7 +144,7 @@ async fn test_mtls_verified() {
     let ca = authly_ca().with_new_key_pair().self_signed();
     let server_cert = ca.sign(server_cert("localhost", Duration::hours(1)).with_new_key_pair());
     let client_cert = ca.sign(
-        client_cert("cf2e74c3f26240908e1b4e8817bfde7c", Duration::hours(1)).with_new_key_pair(),
+        client_cert("e.cf2e74c3f26240908e1b4e8817bfde7c", Duration::hours(1)).with_new_key_pair(),
     );
 
     let rustls_config_factory = rustls_server_config_mtls(&[&server_cert], &ca.der).unwrap();
@@ -167,7 +167,7 @@ async fn test_mtls_verified() {
 
     assert_eq!(
         text_response,
-        "it works: peer_service_eid=cf2e74c3f26240908e1b4e8817bfde7c"
+        "it works: peer_service_eid=e.cf2e74c3f26240908e1b4e8817bfde7c"
     );
 }
 
@@ -199,7 +199,7 @@ async fn test_mtls_server_cert_through_csr() {
 
     // let server_cert = ca.sign(gen_key_pair().server_cert_csr("localhost", Duration::hours(1)));
     let client_cert = ca.sign(
-        client_cert("cf2e74c3f26240908e1b4e8817bfde7c", Duration::hours(1)).with_new_key_pair(),
+        client_cert("e.cf2e74c3f26240908e1b4e8817bfde7c", Duration::hours(1)).with_new_key_pair(),
     );
 
     let rustls_config_factory = rustls_server_config_mtls(&[&server_cert], &ca.der).unwrap();
@@ -222,7 +222,7 @@ async fn test_mtls_server_cert_through_csr() {
 
     assert_eq!(
         text_response,
-        "it works: peer_service_eid=cf2e74c3f26240908e1b4e8817bfde7c"
+        "it works: peer_service_eid=e.cf2e74c3f26240908e1b4e8817bfde7c"
     );
 }
 


### PR DESCRIPTION
IDs are now not a mess anymore, `ObjId` is removed, IDs are now byte-tagged in the the database so that it is possible to figure out what kind of ID it is. It is 17 bytes on disk instead of 16. Also make strongly-typed IDs for all the different Authly objects. This has the potential to make the model more flexible.