### PR TITLE
feat: more realistic production-grade OpenBao setup for k8s

### DIFF
--- a/justfile
+++ b/justfile
@@ -97,11 +97,9 @@ k8s-test-deploy: generate-testdata dev-image testservice-image k8s-test-setup
     kubectl apply -f testfiles/k8s/arx.yaml
     kubectl apply -f testfiles/k8s/routing.yaml
 
-    kubectl delete pods --namespace=authly-test -l 'app=openbao' &
-    kubectl delete pods --namespace=authly-test -l 'app=authly' &
-    kubectl delete pods --namespace=authly-test -l 'app=testservice' &
-    kubectl delete pods --namespace=authly-test -l 'app=arx' &
-    wait
+    kubectl delete pods --namespace=authly-test -l 'app=authly'
+    kubectl delete pods --namespace=authly-test -l 'app=testservice'
+    kubectl delete pods --namespace=authly-test -l 'app=arx'
 
 # rebuild authly and restart its kubernetes pods
 k8s-test-refresh-authly: dev-image

--- a/justfile
+++ b/justfile
@@ -91,11 +91,13 @@ testservice-image:
 
 # deploy local development version of authly to authly-test k8s namespace. Cluster should be a k3d cluster running k3d-registry-dockerd.
 k8s-test-deploy: generate-testdata dev-image testservice-image k8s-test-setup
+    kubectl apply -f testfiles/k8s/openbao.yaml
     kubectl apply -f testfiles/k8s/authly.yaml
     kubectl apply -f testfiles/k8s/testservice.yaml
     kubectl apply -f testfiles/k8s/arx.yaml
     kubectl apply -f testfiles/k8s/routing.yaml
 
+    kubectl delete pods --namespace=authly-test -l 'app=openbao' &
     kubectl delete pods --namespace=authly-test -l 'app=authly' &
     kubectl delete pods --namespace=authly-test -l 'app=testservice' &
     kubectl delete pods --namespace=authly-test -l 'app=arx' &

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -102,6 +102,16 @@ struct PalOutput {
 }
 
 #[derive(Deserialize)]
+struct BaoAuthOutput {
+    pub auth: BaoAuthData,
+}
+
+#[derive(Deserialize)]
+struct BaoAuthData {
+    pub client_token: String,
+}
+
+#[derive(Deserialize)]
 struct BaoCreateSecretOutput {
     pub data: BaoCreateSecretData,
 }
@@ -179,16 +189,13 @@ pub async fn load_decrypted_deks(
 async fn gen_new_master(env_config: &EnvConfig) -> anyhow::Result<DecryptedMaster> {
     if let Some(bao_url) = &env_config.bao_url {
         let id = &env_config.id;
-        let Some(bao_token) = &env_config.bao_token else {
-            return Err(anyhow!("fatal: no bao token set"));
-        };
+        let bao_token = get_bao_token(env_config).await?;
+
         let mut plaintext: [u8; 32] = [0; 32];
-
         OsRng.fill(plaintext.as_mut_slice());
-
         let master = Hex(plaintext.to_vec());
 
-        let vault_output: BaoCreateSecretOutput = reqwest::Client::new()
+        let bao_output: BaoCreateSecretOutput = reqwest::Client::new()
             .post(format!("{bao_url}/v1/secret/data/authly-master-key-{id}"))
             .header("x-vault-token", bao_token.clone())
             .json(&json!({
@@ -199,11 +206,11 @@ async fn gen_new_master(env_config: &EnvConfig) -> anyhow::Result<DecryptedMaste
             .send()
             .await?
             .error_for_status()
-            .context("fatal: vault error")?
+            .context("fatal: failed to create master key in bao")?
             .json()
             .await?;
 
-        let version = vault_output.data.version;
+        let version = bao_output.data.version;
 
         Ok(DecryptedMaster {
             encrypted: MasterVersion {
@@ -212,28 +219,6 @@ async fn gen_new_master(env_config: &EnvConfig) -> anyhow::Result<DecryptedMaste
             },
             key: AesKey {
                 key: load_key(master.0)?,
-            },
-        })
-    } else if let Some(pal_url) = &env_config.pal_url {
-        let pal_output: PalOutput = reqwest::Client::new()
-            .post(format!("{pal_url}/api/v0/key"))
-            .json(&json!({
-                "key_id": "authly-master",
-            }))
-            .send()
-            .await?
-            .error_for_status()
-            .context("fatal: authly-pal error")?
-            .json()
-            .await?;
-
-        Ok(DecryptedMaster {
-            encrypted: MasterVersion {
-                version: pal_output.version.0,
-                created_at: time::OffsetDateTime::now_utc(),
-            },
-            key: AesKey {
-                key: load_key(pal_output.plaintext.0)?,
             },
         })
     } else {
@@ -247,12 +232,12 @@ async fn decrypt_master(
 ) -> anyhow::Result<DecryptedMaster> {
     if let Some(bao_url) = &env_config.bao_url {
         let id = &env_config.id;
+        let bao_token = get_bao_token(env_config).await?;
+
         let version: [u8; 8] = encrypted.version.as_slice().try_into().expect("");
         let version = u64::from_be_bytes(version);
-        let Some(bao_token) = &env_config.bao_token else {
-            return Err(anyhow!("fatal: no bao token set"));
-        };
-        let vault_output: BaoReadSecretOutput = reqwest::Client::new()
+
+        let bao_output: BaoReadSecretOutput = reqwest::Client::new()
             .get(format!(
                 "{bao_url}/v1/secret/data/authly-master-key-{id}?version={version}"
             ))
@@ -260,33 +245,13 @@ async fn decrypt_master(
             .send()
             .await?
             .error_for_status()
-            .context("fatal: vault error")?
+            .context("fatal: failed to fetch master key in bao")?
             .json()
             .await?;
         Ok(DecryptedMaster {
             encrypted,
             key: AesKey {
-                key: load_key(vault_output.data.data.master_key.0.into_iter())?,
-            },
-        })
-    } else if let Some(pal_url) = &env_config.pal_url {
-        let pal_output: PalOutput = reqwest::Client::new()
-            .post(format!("{pal_url}/api/v0/key"))
-            .json(&json!({
-                "key_id": "authly-master",
-                "version": hexhex::hex(&encrypted.version).to_string(),
-            }))
-            .send()
-            .await?
-            .error_for_status()
-            .context("fatal: authly-crypt error")?
-            .json()
-            .await?;
-
-        Ok(DecryptedMaster {
-            encrypted,
-            key: AesKey {
-                key: load_key(pal_output.plaintext.0)?,
+                key: load_key(bao_output.data.data.master_key.0.into_iter())?,
             },
         })
     } else {
@@ -358,4 +323,31 @@ pub fn random_nonce() -> Nonce<Aes256GcmSiv> {
 pub fn nonce_from_slice(slice: &[u8]) -> anyhow::Result<Nonce<Aes256GcmSiv>> {
     Nonce::<Aes256GcmSiv>::from_exact_iter(slice.iter().copied())
         .ok_or_else(|| anyhow!("invalid nonce length"))
+}
+
+async fn get_bao_token(env_config: &EnvConfig) -> anyhow::Result<String> {
+    if let Some(bao_token) = &env_config.bao_token {
+        Ok(bao_token.clone())
+    } else if env_config.k8s {
+        let svc_token =
+            std::fs::read_to_string("/var/run/secrets/kubernetes.io/serviceaccount/token").unwrap();
+        let Some(bao_url) = &env_config.bao_url else {
+            panic!("fatal: no bao url found")
+        };
+        let bao_output: BaoAuthOutput = reqwest::Client::new()
+            .post(format!("{bao_url}/v1/auth/kubernetes/login"))
+            .json(&json!({
+                "role": "authly",
+                "jwt": svc_token,
+            }))
+            .send()
+            .await?
+            .error_for_status()
+            .context("fatal: bao authentication error")?
+            .json()
+            .await?;
+        Ok(bao_output.auth.client_token)
+    } else {
+        panic!("fatal: no bao token found")
+    }
 }

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -96,12 +96,6 @@ impl AesKey {
 }
 
 #[derive(Deserialize)]
-struct PalOutput {
-    pub version: Hex,
-    pub plaintext: Hex,
-}
-
-#[derive(Deserialize)]
 struct BaoAuthOutput {
     pub auth: BaoAuthData,
 }

--- a/src/env_config.rs
+++ b/src/env_config.rs
@@ -37,6 +37,7 @@ pub struct EnvConfig {
 
     /// OpenBao URL for master encryption key storage
     pub bao_url: Option<String>,
+
     /// OpenBao token support for legacy setups
     pub bao_token: Option<String>,
 

--- a/src/env_config.rs
+++ b/src/env_config.rs
@@ -35,8 +35,9 @@ pub struct EnvConfig {
     /// Database directory
     pub data_dir: PathBuf,
 
-    pub pal_url: Option<String>,
+    /// OpenBao URL for master encryption key storage
     pub bao_url: Option<String>,
+    /// OpenBao token support for legacy setups
     pub bao_token: Option<String>,
 
     pub cluster_node_id: Option<u64>,
@@ -94,7 +95,6 @@ impl Default for EnvConfig {
             etc_dir: PathBuf::from("/etc/authly"),
             data_dir: PathBuf::from("/var/lib/authly/data"),
 
-            pal_url: None,
             bao_url: None,
             bao_token: None,
 

--- a/testfiles/docker/docker-compose.yml
+++ b/testfiles/docker/docker-compose.yml
@@ -32,6 +32,7 @@ services:
   openbao:
     image: ghcr.io/openbao/openbao
     environment:
+      # do not use this approach in production
       BAO_DEV_ROOT_TOKEN_ID: theenigmaticbaobunofancientsecrets
     command: server -dev
 

--- a/testfiles/k8s/authly.yaml
+++ b/testfiles/k8s/authly.yaml
@@ -39,7 +39,7 @@ metadata:
   name: authly-config
 data:
   AUTHLY_ID: 05f06a77d9a06a7d31c43ad931f1f7669495363df30224f7b129b54f16c3b768
-  AUTHLY_PAL_URL: "http://localhost:6666"
+  AUTHLY_BAO_URL: "http://openbao:8200"
   AUTHLY_K8S: "true"
   AUTHLY_K8S_AUTH_HOSTNAME: authly-k8s
   AUTHLY_K8S_AUTH_SERVER_PORT: "2443"
@@ -192,13 +192,6 @@ spec:
             requests:
               memory: 32Mi
               cpu: 100m
-      initContainers:
-        - name: authly-pal
-          image: protojour/authly-pal:dev
-          restartPolicy: Always
-          env:
-            - name: K8S_INSECURE
-              value: "true"
       volumes:
         - name: authly-cluster-key
           secret:

--- a/testfiles/k8s/openbao.yaml
+++ b/testfiles/k8s/openbao.yaml
@@ -1,0 +1,258 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openbao
+  namespace: authly-test
+  labels:
+    helm.sh/chart: openbao-0.7.0
+    app.kubernetes.io/name: openbao
+    app.kubernetes.io/instance: openbao
+    app.kubernetes.io/managed-by: Helm
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openbao-server-binding
+  labels:
+    helm.sh/chart: openbao-0.7.0
+    app.kubernetes.io/name: openbao
+    app.kubernetes.io/instance: openbao
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: openbao
+    namespace: authly-test
+---
+# Service for OpenBao cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: openbao-internal
+  namespace: authly-test
+  labels:
+    helm.sh/chart: openbao-0.7.0
+    app.kubernetes.io/name: openbao
+    app.kubernetes.io/instance: openbao
+    app.kubernetes.io/managed-by: Helm
+    openbao-internal: "true"
+  annotations:
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: "http"
+      port: 8200
+      targetPort: 8200
+    - name: https-internal
+      port: 8201
+      targetPort: 8201
+  selector:
+    app.kubernetes.io/name: openbao
+    app.kubernetes.io/instance: openbao
+    component: server
+---
+# Service for OpenBao cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: openbao
+  namespace: authly-test
+  labels:
+    helm.sh/chart: openbao-0.7.0
+    app.kubernetes.io/name: openbao
+    app.kubernetes.io/instance: openbao
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+spec:
+  # We want the servers to become available even if they're not ready
+  # since this DNS is also used for join operations.
+  publishNotReadyAddresses: true
+  ports:
+    - name: http
+      port: 8200
+      targetPort: 8200
+    - name: https-internal
+      port: 8201
+      targetPort: 8201
+  selector:
+    app.kubernetes.io/name: openbao
+    app.kubernetes.io/instance: openbao
+    component: server
+---
+# ConfigMap for Authly policy
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authly-policy-map
+  namespace: authly-test
+data:
+  authly_policy.hcl: |
+    # Allow token to create, update and read secrets at the given path
+    path "secret/data/authly-*" {
+      capabilities = ["create", "update", "read"]
+    }
+    # Allow tokens to look up their own properties
+    path "auth/token/lookup-self" {
+        capabilities = ["read"]
+    }
+    # Allow tokens to renew themselves
+    path "auth/token/renew-self" {
+        capabilities = ["update"]
+    }
+    # Allow tokens to revoke themselves
+    path "auth/token/revoke-self" {
+        capabilities = ["update"]
+    }
+---
+# StatefulSet to run the actual openbao server cluster.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: openbao
+  namespace: authly-test
+  labels:
+    app.kubernetes.io/name: openbao
+    app.kubernetes.io/instance: openbao
+    app.kubernetes.io/managed-by: Helm
+spec:
+  serviceName: openbao-internal
+  podManagementPolicy: Parallel
+  replicas: 1
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: openbao
+      app.kubernetes.io/instance: openbao
+      component: server
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: openbao-0.7.0
+        app.kubernetes.io/name: openbao
+        app.kubernetes.io/instance: openbao
+        component: server
+      annotations:
+    spec:
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: openbao
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 1000
+        runAsUser: 100
+        fsGroup: 1000
+      hostNetwork: false
+      volumes:
+        - name: home
+          emptyDir: {}
+        # Authly policy volume mapping
+        - name: authly-policy
+          configMap:
+            name: authly-policy-map
+      containers:
+        - name: openbao
+          image: quay.io/openbao/openbao:2.1.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/bin/sh"
+            - "-ec"
+          args:
+            - |
+              /usr/local/bin/docker-entrypoint.sh bao server -dev
+          securityContext:
+            allowPrivilegeEscalation: false
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: BAO_K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: BAO_K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: BAO_ADDR
+              value: "http://127.0.0.1:8200"
+            - name: BAO_API_ADDR
+              value: "http://$(POD_IP):8200"
+            - name: SKIP_CHOWN
+              value: "true"
+            - name: SKIP_SETCAP
+              value: "true"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: BAO_CLUSTER_ADDR
+              value: "https://$(HOSTNAME).openbao-internal:8201"
+            - name: HOME
+              value: "/home/openbao"
+            - name: VAULT_DEV_ROOT_TOKEN_ID
+              value: theenigmaticbaobunofancientsecrets
+            - name: VAULT_DEV_LISTEN_ADDRESS
+              value: "[::]:8200"
+          volumeMounts:
+            - name: home
+              mountPath: /home/openbao
+            # Mount Authly policy
+            - name: authly-policy
+              mountPath: /tmp/authly_policy.hcl
+              subPath: authly_policy.hcl
+          ports:
+            - containerPort: 8200
+              name: http
+            - containerPort: 8201
+              name: https-internal
+            - containerPort: 8202
+              name: http-rep
+          readinessProbe:
+            # Check status; unsealed openbao servers return 0
+            # The exit code reflects the seal status:
+            #   0 - unsealed
+            #   1 - error
+            #   2 - sealed
+            exec:
+              command: ["/bin/sh", "-ec", "bao status -tls-skip-verify"]
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          lifecycle:
+            # openbao container doesn't receive SIGTERM from Kubernetes
+            # and after the grace period ends, Kube sends SIGKILL.  This
+            # causes issues with graceful shutdowns such as deregistering itself
+            # from Consul (zombie services).
+            preStop:
+              exec:
+                command: [
+                    "/bin/sh",
+                    "-c",
+                    # Adding a sleep here to give the pod eviction a
+                    # chance to propagate, so requests will not be made
+                    # to this pod while it's terminating
+                    "sleep 5 && kill -SIGTERM $(pidof bao)",
+                  ]
+            # Set up openbao for
+            postStart:
+              exec:
+                command: [
+                    "/bin/sh",
+                    "-c",
+                    "bao policy write authly /tmp/authly_policy.hcl && \
+                    bao auth enable kubernetes && \
+                    bao write auth/kubernetes/config kubernetes_host=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT && \
+                    bao write auth/kubernetes/role/authly bound_service_account_names=authly bound_service_account_namespaces=authly-test policies=authly ttl=24h",
+                  ]

--- a/testfiles/k8s/values/openbao.yaml
+++ b/testfiles/k8s/values/openbao.yaml
@@ -1,0 +1,8 @@
+global:
+  namespace: authly-test
+server:
+  dev:
+    enabled: true
+csi:
+  agent:
+    enabled: false

--- a/testfiles/k8s/values/openbao.yaml
+++ b/testfiles/k8s/values/openbao.yaml
@@ -1,8 +1,0 @@
-global:
-  namespace: authly-test
-server:
-  dev:
-    enabled: true
-csi:
-  agent:
-    enabled: false


### PR DESCRIPTION
Docker and dev setups use a static root token for OpenBao (`BAO_TOKEN`), but the example k8s setup has a more realistic OpenBao setup with k8s service token authentication.

`authly-pal` support was removed.