### PR TITLE
feat: service hosts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
 [[package]]
 name = "authly-client"
 version = "0.0.7"
-source = "git+https://github.com/protojour/authly-lib.git#f9b3afee6d5abeec6dbff69f2714ef40bd6cceea"
+source = "git+https://github.com/protojour/authly-lib.git#27206f61b5142da22ac007e14018525a40f649fe"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -413,7 +413,7 @@ dependencies = [
 [[package]]
 name = "authly-common"
 version = "0.0.7"
-source = "git+https://github.com/protojour/authly-lib.git#f9b3afee6d5abeec6dbff69f2714ef40bd6cceea"
+source = "git+https://github.com/protojour/authly-lib.git#27206f61b5142da22ac007e14018525a40f649fe"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -742,7 +742,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1030,7 +1030,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2459,7 +2459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4835,7 +4835,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4851,7 +4851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
  "windows-core",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4860,7 +4860,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4871,7 +4871,7 @@ checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4880,7 +4880,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4890,7 +4890,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4899,7 +4908,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4908,7 +4917,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4917,15 +4941,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4935,9 +4965,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4953,9 +4995,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4965,9 +5019,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/authly-testservice/src/main.rs
+++ b/crates/authly-testservice/src/main.rs
@@ -54,7 +54,7 @@ async fn main() {
             .with_scheme(Scheme::Https)
             .with_tls_config(
                 client
-                    .rustls_server_configurer("testservice", vec!["testservice".to_string()])
+                    .rustls_server_configurer("testservice")
                     .await
                     .unwrap(),
             )

--- a/docs/src/documents.md
+++ b/docs/src/documents.md
@@ -32,19 +32,19 @@ The built-in _attribute triplets_ `"authly:role:authenticate"` and `"authly:role
 The `kubernetes-account` is used by Authly to provision the service with an mTLS client certificate, used for (service) authentication.
 
 ```toml
-{{#include examples/full_example/0_all.toml:10:13}}
+{{#include examples/full_example/0_all.toml:10:14}}
 ```
 
 This defines the `"ultradb"` [service-entity](#service-entity), hosted as a kubernetes service behind the `"arx"`. Service-enitity labels are exposed as _namespaces_ in the Authly model.
 
 ```toml
-{{#include examples/full_example/0_all.toml:15:17}}
+{{#include examples/full_example/0_all.toml:16:19}}
 ```
 
 This defines the `"ultradb_gui"` (_client_) [service-entity](#service-entity), hosted by `"ultradb"`.
 
 ```toml
-{{#include examples/full_example/0_all.toml:19:22}}
+{{#include examples/full_example/0_all.toml:21:24}}
 ```
 
 This defines the [entity-property](#entity-property) `"role"` for the `"ultradb_gui"` client.
@@ -54,7 +54,7 @@ Its attributes are `"user"` and `"admin"`.
 In other words, we make the client responsible for the concept of a (persona) entity role, since users access the service through the client.
 
 ```toml
-{{#include examples/full_example/0_all.toml:24:27}}
+{{#include examples/full_example/0_all.toml:26:29}}
 ```
 
 This defines the [resource-property](#resource-property) `"action"` for the `"ultradb"` service.
@@ -64,7 +64,7 @@ Its attributes are `"read"` and `"write"`.
 In other words, we make the service is responsible for its own resources, since users access resources (data) via the service's API.
 
 ```toml
-{{#include examples/full_example/0_all.toml:29:31}}
+{{#include examples/full_example/0_all.toml:31:33}}
 ```
 
 This defines a [policy](#policy) called `"allow for GUI user"`.
@@ -76,7 +76,7 @@ The policy must either define an `allow` or a `deny` expression. This policy wil
 Referencing the entity-properties above, this should read as *"allow if the Subject has the ultradb_gui role user".*
 
 ```toml
-{{#include examples/full_example/0_all.toml:33:35}}
+{{#include examples/full_example/0_all.toml:35:37}}
 ```
 
 This defines a [policy](#policy) called `"allow for GUI admin"`, similar to the one above.
@@ -84,7 +84,7 @@ This defines a [policy](#policy) called `"allow for GUI admin"`, similar to the 
 Referencing the entity-properties above, this should read as *"allow if the Subject has the ultradb_gui role admin".*
 
 ```toml
-{{#include examples/full_example/0_all.toml:37:39}}
+{{#include examples/full_example/0_all.toml:39:41}}
 ```
 
 This defines a [policy-binding](#policy-binding), from a list of policies to a list of colon-separated attribute triplets (`namespace:label:attribute`).
@@ -92,7 +92,7 @@ This defines a [policy-binding](#policy-binding), from a list of policies to a l
 Referencing the resource-properties and policies, this should read as *"GUI users and GUI admins are allowed the ultradb action read"*.
 
 ```toml
-{{#include examples/full_example/0_all.toml:41:43}}
+{{#include examples/full_example/0_all.toml:43:45}}
 ```
 
 This defines a [policy-binding](#policy-binding), from a list of policies to a list of colon-separated attribute triplets (`namespace:label:attribute`).
@@ -100,7 +100,7 @@ This defines a [policy-binding](#policy-binding), from a list of policies to a l
 Referencing the resource-properties and policies, this should read as *"GUI admins are allowed the ultradb action write"*.
 
 ```toml
-{{#include examples/full_example/0_all.toml:45:47}}
+{{#include examples/full_example/0_all.toml:47:49}}
 ```
 
 This defines a (persona) [entity](#entity), `"Mr. User"`. For now, they don't have any access credentials.
@@ -108,13 +108,13 @@ This defines a (persona) [entity](#entity), `"Mr. User"`. For now, they don't ha
 Persona entity ids are prefixed by `p.`.
 
 ```toml
-{{#include examples/full_example/0_all.toml:49:51}}
+{{#include examples/full_example/0_all.toml:51:53}}
 ```
 
 This defines a (persona) [entity](#entity), `"Ms. Admin"`. For now, they don't have any access credentials.
 
 ```toml
-{{#include examples/full_example/0_all.toml:53:55}}
+{{#include examples/full_example/0_all.toml:55:57}}
 ```
 
 This defines an [entity-attribute-assignment](#entity-attribute-assignment).
@@ -122,7 +122,7 @@ This defines an [entity-attribute-assignment](#entity-attribute-assignment).
 Referencing the entities and entity-properties above, this should read as *"Mr. User has the ultradb_gui role user"*.
 
 ```toml
-{{#include examples/full_example/0_all.toml:57:59}}
+{{#include examples/full_example/0_all.toml:59:61}}
 ```
 
 This defines an [entity-attribute-assignment](#entity-attribute-assignment).
@@ -179,6 +179,7 @@ Services are authenticated through client certificates rather than traditional c
 - `label`: A label for the entity visible in the document namespace.
 - `attributes`: Attributes bound to the entity. See [entity-attribute-assignment](#entity-attribute-assignment).
 - `metadata`: Metadata about this entity. The metadata is not used by authly itself, but can be used by services which have read access to the entity.
+- `hosts`: List of service hostnames.
 - `kubernetes-account`: An optional Kubernetes account definition.
 
 **Example:**

--- a/docs/src/examples/full_example/0_all.toml
+++ b/docs/src/examples/full_example/0_all.toml
@@ -10,11 +10,13 @@ kubernetes-account = { name = "arx", namespace = "ultradb" }
 [[service-entity]]
 eid = "s.ec29ba1d23cb43f89b7c73db6f177a1d"
 label = "ultradb"
+hosts = ["ultradb"]
 kubernetes-account = { name = "ultradb", namespace = "ultradb" }
 
 [[service-entity]]
 eid = "s.a1c6134658dd4120823fdc42bb2f42ad"
 label = "ultradb_gui"
+hosts = ["ultradb-gui"]
 
 [[entity-property]]
 namespace = "ultradb_gui"

--- a/examples/demo/2_testservice.toml
+++ b/examples/demo/2_testservice.toml
@@ -5,6 +5,7 @@ id = "bc9ce588-50c3-47d1-94c1-f88b21eaf299"
 eid = "s.f3e799137c034e1eb4cd3e4f65705932"
 label = "testservice"
 attributes = ["authly:role:authenticate", "authly:role:get_access_token"]
+hosts = ["testservice"]
 kubernetes-account = { name = "testservice", namespace = "authly-test" }
 
 [[entity-property]]

--- a/examples/ultradb/0_ultradb.toml
+++ b/examples/ultradb/0_ultradb.toml
@@ -14,11 +14,13 @@ kubernetes-account = { name = "arx", namespace = "memoriam-test" }
 eid = "s.ec29ba1d23cb43f89b7c73db6f177a1d"
 label = "ultradb"
 attributes = []
+hosts = ["ultradb"]
 kubernetes-account = { name = "domaindb", namespace = "dbtest" }
 
 [[service-entity]]
 eid = "s.a1c6134658dd4120823fdc42bb2f42ad"
 label = "ultradb_gui"
+hosts = ["ultradb-gui"]
 
 [[entity-property]]
 namespace = "ultradb_gui"

--- a/migrations/1_init.sql
+++ b/migrations/1_init.sql
@@ -141,7 +141,8 @@ CREATE TABLE ns_res_attrlabel (
 -- Service entities
 CREATE TABLE svc (
     dir_id BLOB NOT NULL,
-    svc_eid BLOB NOT NULL PRIMARY KEY
+    svc_eid BLOB NOT NULL PRIMARY KEY,
+    hosts_json TEXT
 );
 
 -- Service: namespace participation

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     encryption::DecryptedDeks,
     instance::AuthlyInstance,
+    platform::CertificateDistributionPlatform,
     AuthlyCtx,
 };
 
@@ -70,6 +71,11 @@ pub trait ServiceBus {
 
 pub trait RedistributeCertificates {
     fn redistribute_certificates_if_leader(&self) -> impl Future<Output = ()>;
+}
+
+pub trait HostsConfig {
+    fn authly_hostname(&self) -> &str;
+    fn is_k8s(&self) -> bool;
 }
 
 impl GetDb for AuthlyCtx {
@@ -144,6 +150,19 @@ impl ServiceBus for AuthlyCtx {
 impl RedistributeCertificates for AuthlyCtx {
     async fn redistribute_certificates_if_leader(&self) {
         crate::platform::redistribute_certificates(self).await;
+    }
+}
+
+impl HostsConfig for AuthlyCtx {
+    fn authly_hostname(&self) -> &str {
+        &self.state.hostname
+    }
+
+    fn is_k8s(&self) -> bool {
+        matches!(
+            self.state.cert_distribution_platform,
+            CertificateDistributionPlatform::KubernetesConfigMap
+        )
     }
 }
 

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -35,7 +35,7 @@ pub async fn apply_document(
 ) -> Result<(), DirectoryError> {
     let dir_id = compiled_doc.dir_id;
 
-    let service_ids = compiled_doc.data.service_ids.clone();
+    let service_ids: Vec<_> = compiled_doc.data.services.keys().copied().collect();
 
     let deks = deps.load_decrypted_deks();
 

--- a/src/document/compiled_document.rs
+++ b/src/document/compiled_document.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    ops::Range,
-};
+use std::{collections::BTreeMap, ops::Range};
 
 use authly_common::id::{
     AnyId, AttrId, DirectoryId, DomainId, EntityId, PersonaId, PolicyBindingId, PolicyId, PropId,
@@ -70,7 +67,7 @@ pub struct CompiledDocumentData {
     pub obj_labels: Vec<ObjectLabel>,
     pub entity_password: Vec<EntityPassword>,
 
-    pub service_ids: BTreeSet<ServiceId>,
+    pub services: BTreeMap<ServiceId, CompiledService>,
 
     pub service_domains: Vec<(ServiceId, DomainId)>,
 
@@ -81,6 +78,11 @@ pub struct CompiledDocumentData {
 
     pub policies: Vec<Identified<PolicyId, policy_db::DbPolicy>>,
     pub policy_bindings: Vec<Identified<PolicyBindingId, policy_db::DbPolicyBinding>>,
+}
+
+#[derive(Debug)]
+pub struct CompiledService {
+    pub hosts: Vec<String>,
 }
 
 #[derive(Debug)]

--- a/src/document/doc_compiler.rs
+++ b/src/document/doc_compiler.rs
@@ -19,7 +19,7 @@ use crate::db::directory_db::{DbDirectoryObjectLabel, DbDirectoryPolicy};
 use crate::db::policy_db::DbPolicy;
 use crate::db::{directory_db, policy_db, service_db, Identified};
 use crate::document::compiled_document::{
-    CompiledEntityAttributeAssignment, EntityIdent, ObjectLabel, ObjectTextAttr,
+    CompiledEntityAttributeAssignment, CompiledService, EntityIdent, ObjectLabel, ObjectTextAttr,
 };
 use crate::id::BuiltinProp;
 use crate::policy::compiler::PolicyCompiler;
@@ -223,7 +223,11 @@ pub async fn compile_doc(
             });
         }
 
-        data.service_ids.insert(svc_eid);
+        let service = CompiledService {
+            hosts: mem::take(&mut entity.hosts),
+        };
+
+        data.services.insert(svc_eid, service);
 
         if let Some(metadata) = entity.metadata.take() {
             data.obj_text_attrs.push(ObjectTextAttr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ mod id;
 mod k8s;
 mod openapi;
 mod policy;
+mod service;
 mod settings;
 mod util;
 mod webauth;
@@ -108,6 +109,7 @@ struct AuthlyState {
     cert_distribution_platform: CertificateDistributionPlatform,
     etc_dir: PathBuf,
     export_tls_to_etc: bool,
+    hostname: String,
 }
 
 pub struct Init {
@@ -270,6 +272,7 @@ async fn initialize() -> anyhow::Result<Init> {
             shutdown,
             etc_dir: env_config.etc_dir.clone(),
             export_tls_to_etc: env_config.export_tls_to_etc,
+            hostname: env_config.hostname.clone(),
         }),
     };
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,38 @@
+//! service utilities
+
+use authly_common::id::ServiceId;
+use authly_db::DbError;
+use tracing::info;
+
+use crate::{
+    ctx::{GetDb, HostsConfig},
+    db::service_db,
+};
+
+pub async fn get_service_hosts(
+    deps: &(impl GetDb + HostsConfig),
+    svc_eid: ServiceId,
+) -> anyhow::Result<Vec<String>, DbError> {
+    let base_hosts = service_db::list_service_hosts(deps.get_db(), svc_eid).await?;
+
+    let mut hosts = base_hosts.clone();
+
+    if !base_hosts.is_empty() && deps.is_k8s() {
+        if let Some((namespace, _)) =
+            service_db::get_svc_k8s_account_name(deps.get_db(), svc_eid).await?
+        {
+            for base_host in base_hosts {
+                hosts.push(format!("{base_host}.{namespace}.svc.cluster.local"));
+            }
+        }
+    }
+
+    // hack for "localhost" run, all services will validate to "localhost"
+    if deps.authly_hostname() == "localhost" {
+        hosts.push("localhost".to_string());
+    }
+
+    info!(?svc_eid, ?hosts, "computed service hosts");
+
+    Ok(hosts)
+}

--- a/src/test_support/test_ctx.rs
+++ b/src/test_support/test_ctx.rs
@@ -19,8 +19,8 @@ use crate::{
     },
     cert::{authly_ca, client_cert, key_pair},
     ctx::{
-        ClusterBus, GetDb, GetDecryptedDeks, GetInstance, LoadInstance, RedistributeCertificates,
-        ServiceBus, SetInstance,
+        ClusterBus, GetDb, GetDecryptedDeks, GetInstance, HostsConfig, LoadInstance,
+        RedistributeCertificates, ServiceBus, SetInstance,
     },
     db::cryptography_db,
     encryption::{gen_prop_deks, DecryptedDeks, DecryptedMaster},
@@ -257,6 +257,16 @@ impl ServiceBus for TestCtx {
 impl RedistributeCertificates for TestCtx {
     async fn redistribute_certificates_if_leader(&self) {
         info!("TestCtx redistribute certificates: ignored");
+    }
+}
+
+impl HostsConfig for TestCtx {
+    fn authly_hostname(&self) -> &str {
+        "localhost"
+    }
+
+    fn is_k8s(&self) -> bool {
+        false
     }
 }
 

--- a/src/util/remote_addr.rs
+++ b/src/util/remote_addr.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use hyper::body::Incoming;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RemoteAddr(pub SocketAddr);
 
 pub fn remote_addr_middleware(req: &mut http::Request<Incoming>, addr: SocketAddr) {


### PR DESCRIPTION
To get usable server certificates for services, they now need to specify `hosts = [...]` in the configuration document. 