### PR TITLE
feat: evolve model towards OAuth and other "persona directory" integrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +349,7 @@ dependencies = [
  "humantime",
  "hyper",
  "hyper-util",
+ "indexmap 2.7.1",
  "indoc",
  "int-enum",
  "itertools 0.14.0",
@@ -381,6 +392,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "webpki-roots",
+ "wiremock",
  "x509-parser",
  "zeroize",
 ]
@@ -469,7 +481,7 @@ version = "0.0.0"
 dependencies = [
  "authly-common",
  "bytemuck",
- "deadpool",
+ "deadpool 0.12.2",
  "hexhex",
  "hiqlite",
  "itertools 0.14.0",
@@ -1299,6 +1311,18 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "deadpool"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
@@ -1854,7 +1878,7 @@ dependencies = [
  "bytes",
  "chrono",
  "cryptr",
- "deadpool",
+ "deadpool 0.12.2",
  "dotenvy",
  "fastwebsockets",
  "flume",
@@ -5017,6 +5041,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fff469918e7ca034884c7fd8f93fe27bacb7fcb599fd879df6c7b429a29b646"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.22.1",
+ "deadpool 0.10.0",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ hex = { version = "0.4", features = ["serde"] }
 hexhex = "1"
 hiqlite.workspace = true
 http = "1"
+indexmap = "2.7"
 indoc = "2"
 int-enum = "1"
 itertools = "0.14"
@@ -112,6 +113,7 @@ authly-test-grpc = { path = "lib/authly-test-grpc" }
 async-stream = "0.3"
 criterion = { version = "0.5", default-features = false }
 test-log = { version = "0.2", features = ["trace"] }
+wiremock = "0.6.2"
 
 [[bench]]
 name = "authly_benches"

--- a/migrations/1_init.sql
+++ b/migrations/1_init.sql
@@ -42,7 +42,8 @@ CREATE TABLE directory (
     parent_id BLOB NOT NULL REFERENCES directory(id) DEFERRABLE INITIALLY DEFERRED,
     kind TEXT NOT NULL,
     url TEXT,
-    hash BLOB
+    hash BLOB,
+    label TEXT UNIQUE
 );
 
 CREATE TABLE directory_audit (
@@ -99,6 +100,16 @@ CREATE TABLE obj_text_attr (
     value TEXT NOT NULL,
 
     PRIMARY KEY (obj_id, prop_id)
+);
+
+CREATE TABLE obj_foreign_dir_link (
+    dir_id BLOB NOT NULL REFERENCES directory(id) DEFERRABLE INITIALLY DEFERRED,
+    foreign_id BLOB NOT NULL,
+    obj_id BLOB NOT NULL,
+    upd DATETIME NOT NULL,
+    overwritten INTEGER NOT NULL,
+
+    PRIMARY KEY (dir_id, foreign_id)
 );
 
 -- An object's label in its originating directory/document
@@ -234,4 +245,27 @@ CREATE TABLE am_mandate (
     last_connection_time DATETIME NOT NULL,
 
     UNIQUE (public_key)
+);
+
+CREATE TABLE dir_oauth (
+    dir_id BLOB PRIMARY KEY REFERENCES directory(id) DEFERRABLE INITIALLY DEFERRED,
+    upd DATETIME NOT NULL,
+    client_id TEXT NOT NULL,
+
+    auth_url TEXT NOT NULL,
+    auth_req_scope TEXT,
+    auth_req_client_id_field TEXT,
+    auth_req_nonce_field TEXT,
+    auth_res_code_path TEXT,
+
+    token_url TEXT NOT NULL,
+    token_req_client_id_field TEXT,
+    token_req_client_secret_field TEXT,
+    token_req_code_field TEXT,
+    token_req_callback_url_field TEXT,
+    token_res_access_token_field TEXT,
+
+    user_url TEXT NOT NULL,
+    user_res_id_path TEXT,
+    user_res_email_path TEXT
 );

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -3,6 +3,8 @@ pub mod cryptography_db;
 pub mod directory_db;
 pub mod document_db;
 pub mod entity_db;
+pub mod oauth_db;
+pub mod object_db;
 pub mod policy_db;
 pub mod service_db;
 pub mod session_db;

--- a/src/db/oauth_db.rs
+++ b/src/db/oauth_db.rs
@@ -1,0 +1,132 @@
+use std::borrow::Cow;
+
+use authly_common::id::DirectoryId;
+use authly_db::{param::AsParam, Db, DbResult, FromRow};
+use hiqlite::{params, Param, Params};
+use indoc::indoc;
+
+use crate::{directory::OAuthDirectory, encryption::DecryptedDeks, id::BuiltinProp};
+
+use super::cryptography_db::{CrDbError, EncryptedObjIdent};
+
+pub fn upsert_oauth_directory_stmt(
+    parent_id: DirectoryId,
+    dir_id: DirectoryId,
+    label: &str,
+) -> (Cow<'static, str>, Params) {
+    (
+        indoc! {
+            "INSERT INTO directory (parent_id, id, kind, url, hash, label)
+            VALUES ($1, $2, 'persona', $3, $4, $5)
+            ON CONFLICT DO UPDATE SET url = $3, hash = $4, label = $5"
+        }
+        .into(),
+        params!(
+            parent_id.as_param(),
+            dir_id.as_param(),
+            "",
+            vec![0u8; 32],
+            label
+        ),
+    )
+}
+
+impl FromRow for OAuthDirectory {
+    fn from_row(row: &mut impl authly_db::Row) -> Self {
+        Self {
+            dir_id: row.get_id("dir_id"),
+            client_id: row.get_text("client_id"),
+            // Client secret is loaded from separate table
+            client_secret: "".to_string(),
+            auth_url: row.get_text("auth_url"),
+            auth_req_scope: row.get_opt_text("auth_req_scope"),
+            auth_req_client_id_field: row.get_opt_text("auth_req_client_id_field"),
+            auth_req_nonce_field: row.get_opt_text("auth_req_nonce_field"),
+            auth_res_code_path: row.get_opt_text("auth_res_code_path"),
+            token_url: row.get_text("token_url"),
+            token_req_client_id_field: row.get_opt_text("token_req_client_id_field"),
+            token_req_client_secret_field: row.get_opt_text("token_req_client_secret_field"),
+            token_req_code_field: row.get_opt_text("token_req_code_field"),
+            token_req_callback_url_field: row.get_opt_text("token_req_callback_url_field"),
+            token_res_access_token_field: row.get_opt_text("token_res_access_token_field"),
+            user_url: row.get_text("user_url"),
+            user_res_id_path: row.get_opt_text("user_res_id_path"),
+            user_res_email_path: row.get_opt_text("user_res_email_path"),
+        }
+    }
+}
+
+impl OAuthDirectory {
+    pub async fn query(deps: &impl Db) -> DbResult<Vec<Self>> {
+        deps.query_map("SELECT * FROM dir_oauth".into(), params!())
+            .await
+    }
+
+    pub fn upsert_stmt() -> Cow<'static, str> {
+        indoc! {
+            "
+            INSERT INTO dir_oauth (
+                dir_id, upd, client_id,
+                auth_url, auth_req_scope, auth_req_client_id_field, auth_req_nonce_field, auth_res_code_path,
+                token_url, token_req_client_id_field, token_req_client_secret_field, token_req_code_field, token_req_callback_url_field, token_res_access_token_field,
+                user_url, user_res_id_path, user_res_email_path
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+            ON CONFLICT DO UPDATE SET
+                upd = $2,
+                client_id = $3,
+                auth_url = $4,
+                auth_req_scope = $5,
+                auth_req_client_id_field = $6,
+                auth_req_nonce_field = $7,
+                auth_res_code_path = $8,
+                token_url = $9,
+                token_req_client_id_field = $10,
+                token_req_client_secret_field = $11,
+                token_req_code_field = $12,
+                token_req_callback_url_field = $13,
+                token_res_access_token_field = $14,
+                user_url = $15,
+                user_res_id_path = $16,
+                user_res_email_path = $17
+            "
+        }
+        .into()
+    }
+
+    pub fn upsert_params(self, now: i64) -> Params {
+        params!(
+            self.dir_id.as_param(),
+            now,
+            self.client_id,
+            self.auth_url,
+            self.auth_req_scope,
+            self.auth_req_client_id_field,
+            self.auth_req_nonce_field,
+            self.auth_res_code_path,
+            self.token_url,
+            self.token_req_client_id_field,
+            self.token_req_client_secret_field,
+            self.token_req_code_field,
+            self.token_req_callback_url_field,
+            self.token_res_access_token_field,
+            self.user_url,
+            self.user_res_id_path,
+            self.user_res_email_path
+        )
+    }
+
+    pub fn upsert_secret_stmt(
+        &self,
+        parent_dir_id: DirectoryId,
+        now: i64,
+        deks: &DecryptedDeks,
+    ) -> Result<(Cow<'static, str>, Params), CrDbError> {
+        Ok(EncryptedObjIdent::encrypt(
+            BuiltinProp::OAuthClientSecret.into(),
+            &self.client_secret,
+            deks,
+        )
+        .map_err(CrDbError::Crypto)?
+        .upsert_stmt(parent_dir_id, self.dir_id.upcast(), now))
+    }
+}

--- a/src/db/object_db.rs
+++ b/src/db/object_db.rs
@@ -1,0 +1,32 @@
+use authly_common::id::{AnyId, PropId};
+use authly_db::{param::AsParam, Db, DbResult, FromRow};
+use hiqlite::{params, Param};
+use indoc::indoc;
+
+pub async fn find_obj_id_by_ident_fingerprint(
+    deps: &impl Db,
+    ident_prop_id: PropId,
+    ident_fingerprint: &[u8],
+) -> DbResult<Option<AnyId>> {
+    struct TypedRow(AnyId);
+
+    impl FromRow for TypedRow {
+        fn from_row(row: &mut impl authly_db::Row) -> Self {
+            Self(row.get_id("obj_id"))
+        }
+    }
+
+    Ok(deps
+        .query_map_opt::<TypedRow>(
+            indoc! {
+                "
+                SELECT obj_id FROM obj_ident
+                WHERE prop_id = $1 AND fingerprint = $2
+                ",
+            }
+            .into(),
+            params!(ident_prop_id.as_param(), ident_fingerprint),
+        )
+        .await?
+        .map(|row| row.0))
+}

--- a/src/id.rs
+++ b/src/id.rs
@@ -34,6 +34,7 @@ pub enum BuiltinProp {
     /// The kubernetes service account actually used by this authly instance.
     /// The namespace will be resolved to authly's namespace if it's a wildcard in configuration.
     K8sLocalServiceAccount = 9,
+    OAuthClientSecret = 10,
 }
 
 #[expect(clippy::enum_variant_names)]
@@ -75,17 +76,19 @@ impl BuiltinProp {
             Self::AuthlyInstance => None,
             Self::RelEntityMembership => None,
             Self::Metadata => None,
+            Self::OAuthClientSecret => None,
         }
     }
 
     pub const fn is_encrypted(self) -> bool {
         match self {
             Self::Entity | Self::AuthlyRole | Self::RelEntityMembership | Self::Metadata => false,
+            Self::PasswordHash => false,
+            Self::K8sConfiguredServiceAccount | Self::K8sLocalServiceAccount => false,
             Self::Username => true,
             Self::Email => true,
-            Self::PasswordHash => false,
-            Self::K8sConfiguredServiceAccount | Self::K8sLocalServiceAccount => true,
             Self::AuthlyInstance => true,
+            Self::OAuthClientSecret => true,
         }
     }
 

--- a/src/openapi/admin.rs
+++ b/src/openapi/admin.rs
@@ -106,7 +106,7 @@ pub async fn post_authority_mandate_submission_token(
 ) -> Result<Response, Response> {
     let token = submission::authority::authority_generate_submission_token(
         &ctx,
-        proxied_base_uri.uri.to_string(),
+        proxied_base_uri.to_string(),
         Actor(auth.user_claims.authly.entity_id),
         None,
     )

--- a/src/persona_directory.rs
+++ b/src/persona_directory.rs
@@ -1,0 +1,125 @@
+use authly_common::id::{DirectoryId, PersonaId};
+use authly_db::{DbError, DidInsert};
+use tracing::info;
+
+use crate::{
+    ctx::{GetDb, GetDecryptedDeks},
+    db::{
+        cryptography_db::EncryptedObjIdent,
+        entity_db::{self, OverwritePersonaId},
+        object_db,
+    },
+    id::BuiltinProp,
+};
+
+// A persona whose source is a 3rd-party directory (OAuth/LDAP/etc)
+pub struct ForeignPersona {
+    pub foreign_id: Vec<u8>,
+    pub email: String,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ForeignLinkError {
+    #[error("db error: {0}")]
+    Db(#[from] DbError),
+
+    #[error("encryption error: {0}")]
+    Encryption(anyhow::Error),
+
+    #[error("other: {0}")]
+    Other(&'static str),
+}
+
+/// Link or re-link a foreign persona to get an Authly PersonaId
+pub async fn link_foreign_persona(
+    deps: &(impl GetDb + GetDecryptedDeks),
+    persona_dir_id: DirectoryId,
+    foreign: ForeignPersona,
+) -> Result<(PersonaId, DidInsert), ForeignLinkError> {
+    let email = EncryptedObjIdent::encrypt(
+        BuiltinProp::Email.into(),
+        &foreign.email,
+        &deps.get_decrypted_deks(),
+    )
+    .map_err(ForeignLinkError::Encryption)?;
+    let now = time::OffsetDateTime::now_utc();
+
+    info!("email fingerprint: {}", hexhex::hex(&email.fingerprint));
+
+    // I've tried doing both the "link" and the "email upsert" in the same DB statement,
+    // but have given up temporarily.
+    // FIXME: Ideally these should be performed in one transaction. If not it will be possible
+    // to register/link a persona but then the "set email" can fail.
+
+    // allocate random mapped PersonaId or retrieve the previously mapped one
+    let (persona_id, did_insert) = entity_db::upsert_link_foreign_persona(
+        deps.get_db(),
+        persona_dir_id,
+        PersonaId::random(),
+        OverwritePersonaId(false),
+        foreign.foreign_id.clone(),
+        now,
+    )
+    .await?;
+
+    match email
+        .clone()
+        .insert(
+            deps.get_db(),
+            persona_dir_id,
+            persona_id.upcast(),
+            now.unix_timestamp(),
+        )
+        .await
+    {
+        Ok(()) => Ok((persona_id, did_insert)),
+        Err(db_err) => {
+            info!(?db_err, "email constraint violation");
+
+            // two scenarios
+            if let Some(obj_id) = object_db::find_obj_id_by_ident_fingerprint(
+                deps.get_db(),
+                BuiltinProp::Email.into(),
+                &email.fingerprint,
+            )
+            .await?
+            {
+                // 1. the email already exists for another entity
+
+                let owner_id = PersonaId::try_from(obj_id)
+                    .map_err(|_| ForeignLinkError::Other("email address owned by non-persona"))?;
+
+                info!("writing new persona link for {owner_id}");
+
+                // update the old link to the persona owning the email address
+                let (persona_id, _) = entity_db::upsert_link_foreign_persona(
+                    deps.get_db(),
+                    persona_dir_id,
+                    owner_id,
+                    OverwritePersonaId(true),
+                    foreign.foreign_id,
+                    now,
+                )
+                .await?;
+
+                Ok((persona_id, did_insert))
+            } else {
+                // 2. the persona id already has another email address
+
+                // BUG: the new address should not be written unconditionally,
+                // especially if that directory is not the "manager" of the email address.
+                email
+                    .clone()
+                    .upsert(
+                        deps.get_db(),
+                        persona_dir_id,
+                        persona_id.upcast(),
+                        now.unix_timestamp(),
+                    )
+                    .await?;
+
+                Ok((persona_id, did_insert))
+            }
+        }
+    }
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -44,6 +44,7 @@ mod test_docs_clause_examples;
 mod test_docs_full_example;
 mod test_document;
 mod test_metadata;
+mod test_oauth;
 mod test_tls;
 mod test_ultradb;
 

--- a/src/tests/test_oauth.rs
+++ b/src/tests/test_oauth.rs
@@ -1,0 +1,310 @@
+use authly_common::id::DirectoryId;
+use authly_db::Db;
+use axum::extract::{Path, Query, State};
+use rand::{rngs::OsRng, Rng};
+use serde_json::json;
+use wiremock::{
+    matchers::{header, method, path, query_param},
+    Mock, ResponseTemplate,
+};
+
+use crate::{
+    ctx::{GetDb, GetDecryptedDeks},
+    db::{cryptography_db::EncryptedObjIdent, oauth_db::upsert_oauth_directory_stmt, object_db},
+    directory::{load_persona_directories, OAuthDirectory, PersonaDirectory},
+    id::BuiltinProp,
+    persona_directory::{self, ForeignPersona},
+    test_support::TestCtx,
+    util::base_uri::ProxiedBaseUri,
+    web::oauth::OAuthState,
+};
+
+fn random_oauth(dir_id: DirectoryId) -> OAuthDirectory {
+    fn rnd() -> String {
+        let mut bytes = [0; 8];
+        OsRng.fill(bytes.as_mut_slice());
+        hexhex::hex(bytes).to_string()
+    }
+
+    OAuthDirectory {
+        dir_id,
+        client_id: rnd(),
+        client_secret: "".to_string(),
+        auth_url: rnd(),
+        auth_req_scope: Some(rnd()),
+        auth_req_client_id_field: Some(rnd()),
+        auth_req_nonce_field: Some(rnd()),
+        auth_res_code_path: Some(rnd()),
+        token_url: rnd(),
+        token_req_client_id_field: Some(rnd()),
+        token_req_client_secret_field: Some(rnd()),
+        token_req_code_field: Some(rnd()),
+        token_req_callback_url_field: Some(rnd()),
+        token_res_access_token_field: Some(rnd()),
+        user_url: rnd(),
+        user_res_id_path: Some(rnd()),
+        user_res_email_path: Some(rnd()),
+    }
+}
+
+fn github_like(dir_id: DirectoryId, web_base_url: &str, api_base_url: &str) -> OAuthDirectory {
+    OAuthDirectory {
+        dir_id,
+        client_id: "123".to_string(),
+        client_secret: "456".to_string(),
+        auth_url: format!("{web_base_url}/login/oauth/authorize"),
+        auth_req_scope: Some("user:email".to_string()),
+        auth_req_client_id_field: Some("client_id".to_string()),
+        auth_req_nonce_field: Some("state".to_string()),
+        auth_res_code_path: Some("code".to_string()),
+        token_url: format!("{web_base_url}/login/oauth/access_token"),
+        token_req_client_id_field: Some("client_id".to_string()),
+        token_req_client_secret_field: Some("client_secret".to_string()),
+        token_req_code_field: Some("code".to_string()),
+        token_req_callback_url_field: Some("redirect_uri".to_string()),
+        token_res_access_token_field: Some("access_token".to_string()),
+        user_url: format!("{api_base_url}/user"),
+        user_res_id_path: Some("id".to_string()),
+        user_res_email_path: Some("email".to_string()),
+    }
+}
+
+#[tokio::test]
+async fn test_insert_update_list_oauth_directory() {
+    let ctx = TestCtx::new().inmemory_db().await.supreme_instance().await;
+
+    let dir_id = DirectoryId::random();
+    let now = time::OffsetDateTime::now_utc().unix_timestamp();
+
+    {
+        let (sql, params) = upsert_oauth_directory_stmt(dir_id, dir_id, "buksehub");
+
+        // insert and upsert
+        ctx.get_db()
+            .execute(sql.clone(), params.clone())
+            .await
+            .unwrap();
+        ctx.get_db().execute(sql, params).await.unwrap();
+    }
+
+    let oauth_a = random_oauth(dir_id);
+
+    {
+        let (sql, params) = oauth_a
+            .upsert_secret_stmt(dir_id, now, &ctx.get_decrypted_deks())
+            .unwrap();
+
+        ctx.get_db().execute(sql, params).await.unwrap();
+    }
+
+    ctx.get_db()
+        .execute(OAuthDirectory::upsert_stmt(), oauth_a.upsert_params(now))
+        .await
+        .unwrap();
+
+    let oauth_b = random_oauth(dir_id);
+
+    ctx.get_db()
+        .execute(
+            OAuthDirectory::upsert_stmt(),
+            oauth_b.clone().upsert_params(now),
+        )
+        .await
+        .unwrap();
+
+    let mut dirs = load_persona_directories(ctx.get_db(), &ctx.load_decrypted_deks())
+        .await
+        .unwrap();
+
+    assert_eq!(1, dirs.len());
+    let PersonaDirectory::OAuth(oauth) = dirs.swap_remove("buksehub").unwrap();
+
+    assert_eq!(oauth, oauth_b);
+}
+
+#[test_log::test(tokio::test)]
+async fn test_upsert_persona_link() {
+    let ctx = TestCtx::new()
+        .new_file_db("oauth.db")
+        .await
+        .supreme_instance()
+        .await;
+    let dir_id = DirectoryId::random();
+
+    {
+        let (sql, params) = upsert_oauth_directory_stmt(dir_id, dir_id, "buksehub");
+
+        // insert and upsert
+        ctx.get_db()
+            .execute(sql.clone(), params.clone())
+            .await
+            .unwrap();
+        ctx.get_db().execute(sql, params).await.unwrap();
+    }
+
+    let foreign_id = b"foobar";
+
+    let (persona_id1, did_insert1) = persona_directory::link_foreign_persona(
+        &ctx,
+        dir_id,
+        ForeignPersona {
+            foreign_id: foreign_id.to_vec(),
+            email: "oldmail@mail.com".to_string(),
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(did_insert1.0);
+
+    // NB: currently suboptimal because one entity cannot have more than one email address,
+    // and there can't be any automatic transition because entity idents (e.g. email) are not keyed by directory, they are "global".
+    // Find a way to fix the model.
+    // Maybe the OAuth that _created_ the entity may change the global email.
+    let (persona_id2, did_insert2) = persona_directory::link_foreign_persona(
+        &ctx,
+        dir_id,
+        ForeignPersona {
+            foreign_id: foreign_id.to_vec(),
+            email: "newmail@mail.com".to_string(),
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(!did_insert2.0);
+
+    assert_eq!(
+        persona_id1, persona_id2,
+        "these refer to the same persona because the foreign_id is the same"
+    );
+
+    {
+        let email = EncryptedObjIdent::encrypt(
+            BuiltinProp::Email.into(),
+            "newmail@mail.com",
+            &ctx.get_decrypted_deks(),
+        )
+        .unwrap();
+        let entity_id = object_db::find_obj_id_by_ident_fingerprint(
+            ctx.get_db(),
+            BuiltinProp::Email.into(),
+            &email.fingerprint,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(entity_id, persona_id2.upcast());
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn test_upsert_persona_link_email_disambiguator() {
+    let ctx = TestCtx::new().inmemory_db().await.supreme_instance().await;
+    let dir_a = DirectoryId::random();
+    let dir_b = DirectoryId::random();
+
+    for (dir_id, label) in [dir_a, dir_b]
+        .iter()
+        .copied()
+        .zip(["buksehub", "stillongshub"])
+    {
+        let (sql, params) = upsert_oauth_directory_stmt(dir_id, dir_id, label);
+        ctx.get_db()
+            .execute(sql.clone(), params.clone())
+            .await
+            .unwrap();
+    }
+
+    let shared_email = "addr@mail.com";
+
+    let (persona_id1, _) = persona_directory::link_foreign_persona(
+        &ctx,
+        dir_a,
+        ForeignPersona {
+            foreign_id: b"foreign_a".to_vec(),
+            email: shared_email.to_string(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let (persona_id2, _) = persona_directory::link_foreign_persona(
+        &ctx,
+        dir_b,
+        ForeignPersona {
+            foreign_id: b"foreign_b".to_vec(),
+            email: shared_email.to_string(),
+        },
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        persona_id1, persona_id2,
+        "these refer to the same persona because of a shared email address in two different persona directories"
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn test_callback_github_like() {
+    let dir_id = DirectoryId::random();
+    let code = "c0d3";
+    let hubmock = wiremock::MockServer::start().await;
+    let oauth = github_like(dir_id, &hubmock.uri(), &hubmock.uri());
+
+    let ctx = TestCtx::new()
+        .inmemory_db()
+        .await
+        .supreme_instance()
+        .await
+        .with_persona_directory("buksehub", PersonaDirectory::OAuth(oauth));
+
+    {
+        let (sql, params) = upsert_oauth_directory_stmt(dir_id, dir_id, "buksehub");
+        ctx.get_db()
+            .execute(sql.clone(), params.clone())
+            .await
+            .unwrap();
+    }
+
+    Mock::given(method("POST"))
+        .and(path("/login/oauth/access_token"))
+        .and(query_param("client_id", "123"))
+        .and(query_param("client_secret", "456"))
+        .and(query_param("code", code))
+        .and(query_param(
+            "redirect_uri",
+            "http://localhost/oauth/buksehub/callback",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "gho_16C7e42F292c6912E7710c838347Ae178B4a",
+            "scope": "user:email",
+            "token_type": "bearer"
+        })))
+        .mount(&hubmock)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/user"))
+        .and(header(
+            "authorization",
+            format!("Bearer gho_16C7e42F292c6912E7710c838347Ae178B4a"),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": 42,
+            "email": "user@users.com",
+        })))
+        .mount(&hubmock)
+        .await;
+
+    let _result = crate::web::oauth::oauth_callback(
+        State(OAuthState(ctx)),
+        ProxiedBaseUri("http://localhost".parse().unwrap()),
+        Path("buksehub".to_string()),
+        Query([("code".to_string(), code.to_string())].into()),
+    )
+    .await
+    .unwrap();
+}

--- a/src/util/base_uri.rs
+++ b/src/util/base_uri.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{fmt::Display, str::FromStr};
 
 use http::{
     request::Parts,
@@ -8,8 +8,12 @@ use http::{
 
 /// An extractor that tries to guess the public Uri based on proxy headers
 #[derive(Default)]
-pub struct ProxiedBaseUri {
-    pub uri: Uri,
+pub struct ProxiedBaseUri(pub Uri);
+
+impl Display for ProxiedBaseUri {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 impl ProxiedBaseUri {
@@ -58,9 +62,7 @@ impl ProxiedBaseUri {
             };
         }
 
-        Ok(Self {
-            uri: Uri::from_parts(uri_parts).map_err(|_| ())?,
-        })
+        Ok(Self(Uri::from_parts(uri_parts).map_err(|_| ())?))
     }
 }
 

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,0 +1,18 @@
+use authly_webstatic::static_folder;
+use axum::routing::{get, post};
+
+use crate::AuthlyCtx;
+
+pub mod oauth;
+
+mod auth;
+
+pub fn router() -> axum::Router<AuthlyCtx> {
+    axum::Router::new()
+        // Currently a quirk in the gateway requires this route to be added twice
+        // (`/` is appended by the gateway because /web/auth is a "matcher", => /web/auth/)
+        .route("/web/auth", get(auth::index))
+        .route("/web/auth/", get(auth::index))
+        .nest_service("/web/static", static_folder())
+        .route("/oauth/:label/callback", post(oauth::oauth_callback))
+}

--- a/src/web/oauth.rs
+++ b/src/web/oauth.rs
@@ -1,0 +1,270 @@
+use std::{borrow::Cow, collections::BTreeMap};
+
+use anyhow::{anyhow, Context};
+use axum::{
+    extract::{FromRef, Path, Query, State},
+    response::{IntoResponse, Response},
+};
+use axum_extra::extract::CookieJar;
+use http::StatusCode;
+use rand::{rngs::OsRng, Rng};
+use reqwest::Url;
+use tracing::warn;
+
+use crate::{
+    ctx::{Directories, GetDb, GetDecryptedDeks, GetHttpClient},
+    directory::{OAuthDirectory, PersonaDirectory},
+    persona_directory::{self, ForeignPersona},
+    session::init_session,
+    util::base_uri::ProxiedBaseUri,
+};
+
+pub struct OAuthState<Ctx>(pub Ctx);
+
+impl<Ctx> FromRef<Ctx> for OAuthState<Ctx>
+where
+    Ctx: GetDb + Directories + Clone,
+{
+    fn from_ref(input: &Ctx) -> Self {
+        Self(input.clone())
+    }
+}
+
+#[derive(Debug)]
+#[expect(unused)]
+pub enum OAuthError {
+    PersonaDirectoryNotFound,
+    MissingCode,
+    FetchToken(reqwest::Error),
+    DeserializeToken(reqwest::Error),
+    MissingAccessToken,
+    FetchUser(reqwest::Error),
+    DeserializeUser(reqwest::Error),
+    NoUserId,
+    NoUserEmail,
+    AuthUrl,
+    TokenUrl,
+    CallbackUrl,
+    EntityLink(anyhow::Error),
+    Session(anyhow::Error),
+}
+
+impl IntoResponse for OAuthError {
+    fn into_response(self) -> axum::response::Response {
+        warn!(?self, "OAuth error");
+
+        match self {
+            Self::PersonaDirectoryNotFound => StatusCode::NOT_FOUND.into_response(),
+            Self::MissingCode => StatusCode::UNPROCESSABLE_ENTITY.into_response(),
+            Self::FetchToken(_) | Self::FetchUser(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            }
+            Self::DeserializeToken(_)
+            | Self::MissingAccessToken
+            | Self::DeserializeUser(_)
+            | Self::NoUserId
+            | Self::NoUserEmail => StatusCode::BAD_GATEWAY.into_response(),
+            Self::AuthUrl
+            | Self::TokenUrl
+            | Self::CallbackUrl
+            | Self::EntityLink(_)
+            | Self::Session(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        }
+    }
+}
+
+pub async fn oauth_callback(
+    State(OAuthState(ctx)): State<
+        OAuthState<impl GetDb + Directories + GetHttpClient + GetDecryptedDeks>,
+    >,
+    base_uri: ProxiedBaseUri,
+    Path(label): Path<String>,
+    query: Query<BTreeMap<String, String>>,
+) -> Result<Response, OAuthError> {
+    let persona_directories = ctx.load_persona_directories();
+    let Some(PersonaDirectory::OAuth(oauth)) = persona_directories.get(&label) else {
+        return Err(OAuthError::PersonaDirectoryNotFound);
+    };
+
+    let client = ctx.get_internet_http_client();
+
+    let mut token_response: BTreeMap<String, String> = client
+        .post(build_oauth_token_url(query, &label, oauth, &base_uri)?)
+        .header("accept", "application/json")
+        .send()
+        .await
+        .map_err(OAuthError::FetchToken)?
+        .error_for_status()
+        .map_err(OAuthError::FetchToken)?
+        .json()
+        .await
+        .map_err(OAuthError::DeserializeToken)?;
+
+    let access_token = oauth
+        .token_res_access_token_field
+        .as_deref()
+        .and_then(|field| token_response.remove(field))
+        .ok_or(OAuthError::MissingAccessToken)?;
+
+    let user_response: serde_json::Value = client
+        .get(&oauth.user_url)
+        .header("authorization", format!("Bearer {access_token}"))
+        .header("accept", "application/json")
+        .send()
+        .await
+        .map_err(OAuthError::FetchUser)?
+        .error_for_status()
+        .map_err(OAuthError::FetchUser)?
+        .json()
+        .await
+        .map_err(OAuthError::DeserializeUser)?;
+
+    let user_id = json_str_by_path_opt(&user_response, oauth.user_res_id_path.as_deref())
+        .ok_or(OAuthError::NoUserId)?
+        .map_err(|_| OAuthError::NoUserId)?;
+    let email = json_str_by_path_opt(&user_response, oauth.user_res_email_path.as_deref())
+        .ok_or(OAuthError::NoUserEmail)?
+        .map_err(|_| OAuthError::NoUserEmail)?;
+
+    let (persona_id, _) = persona_directory::link_foreign_persona(
+        &ctx,
+        oauth.dir_id,
+        ForeignPersona {
+            foreign_id: user_id.as_ref().as_bytes().to_vec(),
+            email: email.to_string(),
+        },
+    )
+    .await
+    .map_err(|err| OAuthError::EntityLink(err.into()))?;
+
+    let session = init_session(&ctx, persona_id.upcast())
+        .await
+        .map_err(|err| OAuthError::Session(err.into()))?;
+
+    Ok(CookieJar::new().add(session.to_cookie()).into_response())
+}
+
+/// Build the URL to the external OAuth login website
+#[expect(unused)]
+pub fn build_oauth_web_authorize_url(
+    oauth: &OAuthDirectory,
+    label: &str,
+    base_uri: &ProxiedBaseUri,
+) -> Result<String, OAuthError> {
+    let mut url = Url::parse(&oauth.auth_url).map_err(|_| OAuthError::AuthUrl)?;
+
+    {
+        let mut q = url.query_pairs_mut();
+
+        if let Some(field) = oauth.auth_req_client_id_field.as_deref() {
+            q.append_pair(field, &oauth.client_id);
+        }
+
+        if let Some(field) = oauth.auth_req_nonce_field.as_deref() {
+            let mut nonce = [0u8; 32];
+            OsRng.fill(nonce.as_mut_slice());
+
+            q.append_pair(field, &hexhex::hex(nonce).to_string());
+        }
+
+        // This is optional but recommended for github, but there is no state for not sending this in the DB
+        if let Some(field) = oauth.token_req_callback_url_field.as_deref() {
+            q.append_pair(field, &build_authly_oauth_callback_url(label, base_uri)?);
+        }
+    }
+
+    Ok(url.to_string())
+}
+
+// Build the URL pointing to where the external app will redirect back to Authly
+fn build_authly_oauth_callback_url(
+    label: &str,
+    base_uri: &ProxiedBaseUri,
+) -> Result<String, OAuthError> {
+    let mut url = Url::parse(&base_uri.0.to_string()).map_err(|_| OAuthError::CallbackUrl)?;
+    url.path_segments_mut()
+        .map_err(|_| OAuthError::CallbackUrl)?
+        .extend(["oauth", label, "callback"]);
+
+    Ok(url.as_str().to_string())
+}
+
+/// Build the URL to the web API where the access token can be requested
+fn build_oauth_token_url(
+    mut query: Query<BTreeMap<String, String>>,
+    label: &str,
+    oauth: &OAuthDirectory,
+    base_uri: &ProxiedBaseUri,
+) -> Result<String, OAuthError> {
+    let mut url = Url::parse(&oauth.token_url).map_err(|_| OAuthError::TokenUrl)?;
+
+    {
+        let mut q = url.query_pairs_mut();
+
+        if let Some(field) = oauth.token_req_client_id_field.as_deref() {
+            q.append_pair(field, &oauth.client_id);
+        }
+        if let Some(field) = oauth.token_req_client_secret_field.as_deref() {
+            q.append_pair(field, &oauth.client_secret);
+        }
+
+        if let (Some(input), Some(output)) = (
+            oauth.auth_res_code_path.as_deref(),
+            oauth.token_req_code_field.as_deref(),
+        ) {
+            let code = query.remove(input).ok_or(OAuthError::MissingCode)?;
+            q.append_pair(output, &code);
+        }
+
+        if let Some(field) = oauth.token_req_callback_url_field.as_deref() {
+            q.append_pair(field, &build_authly_oauth_callback_url(label, base_uri)?);
+        }
+    }
+
+    Ok(url.to_string())
+}
+
+fn json_str_by_path_opt<'j>(
+    json: &'j serde_json::Value,
+    path: Option<&str>,
+) -> Option<anyhow::Result<Cow<'j, str>>> {
+    match path.map(|path| json_by_path(json, path))? {
+        Ok(value) => match value {
+            serde_json::Value::Number(number) => Some(Ok(Cow::Owned(number.to_string()))),
+            serde_json::Value::String(string) => Some(Ok(Cow::Borrowed(string))),
+            _ => Some(Err(anyhow!("expected number or string"))),
+        },
+        Err(err) => Some(Err(err)),
+    }
+}
+
+#[expect(unused)]
+fn json_by_path_opt<'j>(
+    json: &'j serde_json::Value,
+    path: Option<&str>,
+) -> Option<anyhow::Result<&'j serde_json::Value>> {
+    path.map(|path| json_by_path(json, path))
+}
+
+fn json_by_path<'j>(
+    json: &'j serde_json::Value,
+    path: &str,
+) -> anyhow::Result<&'j serde_json::Value> {
+    match path.split_once(".") {
+        Some((key, rest)) => {
+            if let serde_json::Value::Object(obj) = json {
+                let value = obj.get(key).context("no such key")?;
+                json_by_path(value, rest)
+            } else {
+                Err(anyhow!("expected object"))
+            }
+        }
+        None => {
+            if let serde_json::Value::Object(obj) = json {
+                Ok(obj.get(path).context("no such key")?)
+            } else {
+                Err(anyhow!("expected object"))
+            }
+        }
+    }
+}


### PR DESCRIPTION
I felt it was important to evolve the model (i.e. the persistence schema) towards integrating external identity providers, called _persona directories_. This is only an experimental initial design, and will evolve. It is based on reading the github OAuth app documentation, no _actual_ testing has been done. Lays the groundwork for "vendor generic" OAuth, though I doubt it really works that way until we try integrating with other vendors.

I have a problem with the the entity `Email` model. Right now a persona has one email address. The initial OpenID link creates a new persona with the email address from OpenID. If you try to integrate with another OpenID vendor, and it presents the same email address, this will result in the same persona, now with 2 OAuth provider links. If the email address from the second provider is different, it will result in a new generated persona. But as mentioned, this model can't represent one entity with different email addresses. It's also unclear how you might "link" another OpenID vendor to your existing persona, since OpenID login+link happens in an Authly "login" context, where the entity is not implied. I think there has to exist an Authly web interface for linking another OpenID vendor, while you are _already_ logged in to Authly as a persona.