### PR TITLE
feat: pure htmx login form

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_spanned",
+ "serde_urlencoded",
  "strum",
  "test-log",
  "thiserror 2.0.11",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ secrecy = "0.10"
 serde = "1"
 serde_json = "1"
 serde_spanned = "0.6"
+serde_urlencoded = "0.7"
 strum = { version = "0.26", features = ["derive"] }
 thiserror = "2"
 time = { version = "0.3", features = ["serde"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use settings::Settings;
 use tokio_util::sync::CancellationToken;
 use tower_server::Scheme;
 use tracing::info;
-use util::{protocol_router::ProtocolRouter, remote_addr::remote_addr_middleware};
+use util::{dev::IsDev, protocol_router::ProtocolRouter, remote_addr::remote_addr_middleware};
 
 // These are public for the integration test crate
 pub mod access_token;
@@ -194,6 +194,7 @@ pub async fn serve() -> anyhow::Result<()> {
                 .with_connection_middleware(|req, _| {
                     req.extensions_mut()
                         .insert(PeerServiceEntity(ServiceId::from_uint(1)));
+                    req.extensions_mut().insert(IsDev(true));
                 })
                 .bind()
                 .await?

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,0 +1,92 @@
+//! traditional username/password login
+
+use argon2::Argon2;
+use authly_common::{id::PersonaId, mtls_server::PeerServiceEntity};
+use authly_db::DbError;
+use tracing::warn;
+
+use crate::{
+    access_control::{authorize_peer_service, SvcAccessControlError},
+    ctx::{GetBuiltins, GetDb, GetDecryptedDeks},
+    db::entity_db::{self, EntityPasswordHash},
+    id::{BuiltinAttr, BuiltinProp},
+    session::{init_session, Session},
+};
+
+pub enum LoginError {
+    UnprivilegedService,
+    Credentials,
+    Db(DbError),
+}
+
+impl From<DbError> for LoginError {
+    fn from(value: DbError) -> Self {
+        Self::Db(value)
+    }
+}
+
+impl From<SvcAccessControlError> for LoginError {
+    fn from(value: SvcAccessControlError) -> Self {
+        match value {
+            SvcAccessControlError::Denied => Self::UnprivilegedService,
+            SvcAccessControlError::Db(db_error) => Self::Db(db_error),
+        }
+    }
+}
+
+pub async fn try_username_password_login(
+    deps: &(impl GetDb + GetBuiltins + GetDecryptedDeks),
+    PeerServiceEntity(peer_svc_eid): PeerServiceEntity,
+    username: String,
+    password: String,
+) -> Result<(PersonaId, Session), LoginError> {
+    authorize_peer_service(deps, peer_svc_eid, &[BuiltinAttr::AuthlyRoleAuthenticate]).await?;
+
+    let ident_fingerprint = {
+        let deks = deps.get_decrypted_deks();
+        let dek = deks.get(BuiltinProp::Username.into()).unwrap();
+
+        dek.fingerprint(username.as_bytes())
+    };
+
+    let ehash = entity_db::find_local_directory_entity_password_hash_by_entity_ident(
+        deps.get_db(),
+        BuiltinProp::Username.into(),
+        &ident_fingerprint,
+        deps.get_builtins(),
+    )
+    .await?
+    .ok_or_else(|| LoginError::Credentials)?;
+
+    let persona_id = verify_secret(ehash, password).await?;
+    let session = init_session(deps, persona_id.upcast()).await?;
+
+    Ok((persona_id, session))
+}
+
+async fn verify_secret(ehash: EntityPasswordHash, secret: String) -> Result<PersonaId, LoginError> {
+    // check Argon2 hash
+    tokio::task::spawn_blocking(move || -> Result<(), LoginError> {
+        use argon2::password_hash::PasswordHash;
+        let hash = PasswordHash::new(&ehash.secret_hash).map_err(|err| {
+            warn!(?err, "invalid secret hash");
+            LoginError::Credentials
+        })?;
+
+        hash.verify_password(&[&Argon2::default()], secret)
+            .map_err(|err| match err {
+                argon2::password_hash::Error::Password => LoginError::Credentials,
+                _ => {
+                    warn!(?err, "failed to verify secret hash");
+                    LoginError::Credentials
+                }
+            })
+    })
+    .await
+    .map_err(|err| {
+        warn!(?err, "failed to join");
+        LoginError::Credentials
+    })??;
+
+    Ok(ehash.eid)
+}

--- a/src/openapi/user_auth.rs
+++ b/src/openapi/user_auth.rs
@@ -1,50 +1,31 @@
-use argon2::Argon2;
 use authly_common::{id::PersonaId, mtls_server::PeerServiceEntity};
-use authly_db::DbError;
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Extension, Json};
 use axum_extra::extract::CookieJar;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
 use crate::{
-    access_control::{authorize_peer_service, SvcAccessControlError},
-    ctx::{GetBuiltins, GetDb},
-    db::entity_db::{self, EntityPasswordHash},
-    id::{BuiltinAttr, BuiltinProp},
-    session::init_session,
+    login::{try_username_password_login, LoginError},
     AuthlyCtx,
 };
 
-pub enum AuthError {
-    UnprivilegedService,
-    UserAuthFailed,
-    Db(DbError),
+pub struct AuthError(LoginError);
+
+impl From<LoginError> for AuthError {
+    fn from(value: LoginError) -> Self {
+        Self(value)
+    }
 }
 
 impl IntoResponse for AuthError {
     fn into_response(self) -> axum::response::Response {
-        match self {
-            Self::UnprivilegedService => StatusCode::FORBIDDEN.into_response(),
-            Self::UserAuthFailed => StatusCode::UNAUTHORIZED.into_response(),
-            Self::Db(err) => {
+        match self.0 {
+            LoginError::UnprivilegedService => StatusCode::FORBIDDEN.into_response(),
+            LoginError::Credentials => StatusCode::UNAUTHORIZED.into_response(),
+            LoginError::Db(err) => {
                 warn!(?err, "auth db error");
                 StatusCode::UNAUTHORIZED.into_response()
             }
-        }
-    }
-}
-
-impl From<DbError> for AuthError {
-    fn from(err: DbError) -> Self {
-        Self::Db(err)
-    }
-}
-
-impl From<SvcAccessControlError> for AuthError {
-    fn from(value: SvcAccessControlError) -> Self {
-        match value {
-            SvcAccessControlError::Denied => Self::UnprivilegedService,
-            SvcAccessControlError::Db(db_error) => Self::Db(db_error),
         }
     }
 }
@@ -73,40 +54,18 @@ pub struct AuthenticateResponse {
 
 pub async fn authenticate(
     State(ctx): State<AuthlyCtx>,
-    Extension(PeerServiceEntity(peer_svc_eid)): Extension<PeerServiceEntity>,
+    Extension(peer_svc): Extension<PeerServiceEntity>,
     Json(body): Json<AuthenticateRequest>,
 ) -> Result<axum::response::Response, AuthError> {
-    authorize_peer_service(&ctx, peer_svc_eid, &[BuiltinAttr::AuthlyRoleAuthenticate]).await?;
-
     // BUG: figure this out:
     let _mfa_needed = false;
     // TODO: directory selection?
 
-    let (ehash, secret) = match body {
+    let (persona_id, session) = match body {
         AuthenticateRequest::User { username, password } => {
-            let prop_id = BuiltinProp::Username.into();
-
-            let ident_fingerprint = {
-                let deks = ctx.deks.load_full();
-                let dek = deks.get(prop_id).unwrap();
-
-                dek.fingerprint(username.as_bytes())
-            };
-
-            let ehash = entity_db::find_local_directory_entity_password_hash_by_entity_ident(
-                ctx.get_db(),
-                BuiltinProp::Username.into(),
-                &ident_fingerprint,
-                ctx.get_builtins(),
-            )
-            .await?
-            .ok_or_else(|| AuthError::UserAuthFailed)?;
-            (ehash, password)
+            try_username_password_login(&ctx, peer_svc, username, password).await?
         }
     };
-
-    let persona_id = verify_secret(ehash, secret).await?;
-    let session = init_session(&ctx, persona_id.upcast()).await?;
 
     Ok((
         CookieJar::new().add(session.to_cookie()),
@@ -123,31 +82,4 @@ pub async fn authenticate(
         }),
     )
         .into_response())
-}
-
-async fn verify_secret(ehash: EntityPasswordHash, secret: String) -> Result<PersonaId, AuthError> {
-    // check Argon2 hash
-    tokio::task::spawn_blocking(move || -> Result<(), AuthError> {
-        use argon2::password_hash::PasswordHash;
-        let hash = PasswordHash::new(&ehash.secret_hash).map_err(|err| {
-            warn!(?err, "invalid secret hash");
-            AuthError::UserAuthFailed
-        })?;
-
-        hash.verify_password(&[&Argon2::default()], secret)
-            .map_err(|err| match err {
-                argon2::password_hash::Error::Password => AuthError::UserAuthFailed,
-                _ => {
-                    warn!(?err, "failed to verify secret hash");
-                    AuthError::UserAuthFailed
-                }
-            })
-    })
-    .await
-    .map_err(|err| {
-        warn!(?err, "failed to join");
-        AuthError::UserAuthFailed
-    })??;
-
-    Ok(ehash.eid)
 }

--- a/src/openapi/user_auth.rs
+++ b/src/openapi/user_auth.rs
@@ -63,7 +63,8 @@ pub async fn authenticate(
 
     let (persona_id, session) = match body {
         AuthenticateRequest::User { username, password } => {
-            try_username_password_login(&ctx, peer_svc, username, password).await?
+            try_username_password_login(&ctx, peer_svc, username, password, Default::default())
+                .await?
         }
     };
 

--- a/src/util/dev.rs
+++ b/src/util/dev.rs
@@ -1,0 +1,17 @@
+use http::request::Parts;
+
+/// Extension and extractor for doing "lower security" versions of APIs in a dev setting
+#[derive(Clone, Copy)]
+pub struct IsDev(pub bool);
+
+#[axum::async_trait]
+impl<S> axum::extract::FromRequestParts<S> for IsDev {
+    type Rejection = ();
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        Ok(match parts.extensions.get::<IsDev>() {
+            Some(is_dev) => *is_dev,
+            None => IsDev(false),
+        })
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod base_uri;
+pub mod dev;
 pub mod error;
 pub mod protocol_router;
 pub mod remote_addr;

--- a/src/web.rs
+++ b/src/web.rs
@@ -13,6 +13,7 @@ pub fn router() -> axum::Router<AuthlyCtx> {
         // (`/` is appended by the gateway because /web/auth is a "matcher", => /web/auth/)
         .route("/web/auth", get(auth::index))
         .route("/web/auth/", get(auth::index))
+        .route("/web/auth/login", post(auth::login))
         .nest_service("/web/static", static_folder())
         .route("/oauth/:label/callback", post(oauth::oauth_callback))
 }

--- a/src/web/auth.rs
+++ b/src/web/auth.rs
@@ -1,22 +1,29 @@
-use http::request::Parts;
-use indoc::indoc;
-use maud::{html, Markup, PreEscaped, DOCTYPE};
+use authly_common::mtls_server::PeerServiceEntity;
+use axum::{
+    extract::{Query, State},
+    response::{IntoResponse, Response},
+    Extension, Form,
+};
+use cookie::CookieJar;
+use http::{request::Parts, HeaderName, HeaderValue};
+use maud::{html, Markup, DOCTYPE};
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
 
-pub async fn index(ForwardedPrefix(prefix): ForwardedPrefix) -> Markup {
-    let js = indoc! {
-        r#"
-        document.body.addEventListener('htmx:afterRequest', function(evt) {
-            if (evt.detail.pathInfo.requestPath.endsWith('/api/auth/authenticate')) {
-                // redirect back to requesting app.
-                const next = new URLSearchParams(window.location.search).get('next');
-                if (next) {
-                    window.location.href = next;
-                }
-            }
-        });
-        "#
-    };
+use crate::{
+    login::{try_username_password_login, LoginError},
+    AuthlyCtx,
+};
 
+#[derive(Serialize, Deserialize)]
+pub struct QueryParams {
+    next: String,
+}
+
+pub async fn index(
+    ForwardedPrefix(prefix): ForwardedPrefix,
+    Query(params): Query<QueryParams>,
+) -> Markup {
     html! {
         (DOCTYPE)
         html {
@@ -26,7 +33,6 @@ pub async fn index(ForwardedPrefix(prefix): ForwardedPrefix) -> Markup {
                 meta name="color-scheme" content="light dark";
                 title { "Authly sign in" }
                 script src={(prefix)"/web/static/vendor/htmx.min.js"} {}
-                script src={(prefix)"/web/static/vendor/json-enc.js"} {}
                 link rel="shortcut icon" href={(prefix)"/web/static/favicon.svg"} type="image/svg+xml";
                 link rel="stylesheet" href={(prefix)"/web/static/vendor/pico.classless.min.css"};
                 link rel="stylesheet" href={(prefix)"/web/static/style.css"};
@@ -37,25 +43,78 @@ pub async fn index(ForwardedPrefix(prefix): ForwardedPrefix) -> Markup {
                         img alt="Authly" src={(prefix)"/web/static/logo.svg"};
                         div class="card" {
                             h2 { "Sign in" }
-                            form hx-post={(prefix)"/api/auth/authenticate"} hx-ext="json-enc" {
-                                div class="inputs" {
-                                    input id="username" name="username" type="text" aria-label="Username" placeholder="Username" required autofocus {}
-                                    input id="password" name="password" type="password" aria-label="Password" placeholder="Password" required {}
-                                }
-                                div {
-                                    button type="submit" {
-                                        svg {
-                                            use href={(prefix)"/web/static/vendor/login.svg#icon"};
-                                        }
-                                        "Sign in"
-                                    }
-                                }
-                            }
+                            (login_form(&prefix, &params, None))
                         }
                     }
                 }
             }
-            script { (PreEscaped(js)) }
+        }
+    }
+}
+
+/// A login form with an optional error message
+fn login_form(prefix: &str, params: &QueryParams, message: Option<&str>) -> Markup {
+    let login_url = format!(
+        "{prefix}/web/auth/login?{}",
+        &serde_urlencoded::to_string(params).unwrap()
+    );
+
+    html!(
+        form hx-post={(login_url)} {
+            div class="inputs" {
+                input id="username" name="username" type="text" aria-label="Username" placeholder="Username" required autofocus {}
+                input id="password" name="password" type="password" aria-label="Password" placeholder="Password" required {}
+            }
+            @if let Some(message) = message {
+                div class="error" {
+                    (message)
+                }
+            }
+            div {
+                button type="submit" {
+                    svg {
+                        use href={(prefix)"/web/static/vendor/login.svg#icon"};
+                    }
+                    "Sign in"
+                }
+            }
+        }
+    )
+}
+
+// NOTE: This is currently sent "unencrypted" and can be MITMed by whoever terminates SSL outside Authly's control,
+// when the web auth routes are exposed on the internet.
+#[derive(Deserialize)]
+pub struct LoginBody {
+    username: String,
+    password: String,
+}
+
+// NOTE: Uses response header `HX-redirect` (https://htmx.org/headers/hx-redirect/)
+pub async fn login(
+    State(ctx): State<AuthlyCtx>,
+    Extension(peer_svc): Extension<PeerServiceEntity>,
+    ForwardedPrefix(prefix): ForwardedPrefix,
+    Query(params): Query<QueryParams>,
+    Form(LoginBody { username, password }): Form<LoginBody>,
+) -> Response {
+    match try_username_password_login(&ctx, peer_svc, username, password).await {
+        Ok((_persona_id, session)) => (
+            CookieJar::new().add(session.to_cookie()),
+            [(
+                HeaderName::from_static("hx-redirect"),
+                HeaderValue::from_str(&params.next).unwrap(),
+            )],
+        )
+            .into_response(),
+        Err(err) => {
+            match err {
+                LoginError::UnprivilegedService => info!("unprivileged service"),
+                LoginError::Credentials => {}
+                LoginError::Db(err) => warn!(?err, "login db error"),
+            }
+
+            login_form(&prefix, &params, Some("Invalid username or password")).into_response()
         }
     }
 }

--- a/src/web/auth.rs
+++ b/src/web/auth.rs
@@ -4,7 +4,6 @@ use axum::{
     response::{IntoResponse, Response},
     Extension, Form,
 };
-use cookie::CookieJar;
 use http::{request::Parts, HeaderName, HeaderValue};
 use maud::{html, Markup, DOCTYPE};
 use serde::{Deserialize, Serialize};
@@ -100,7 +99,7 @@ pub async fn login(
 ) -> Response {
     match try_username_password_login(&ctx, peer_svc, username, password).await {
         Ok((_persona_id, session)) => (
-            CookieJar::new().add(session.to_cookie()),
+            axum_extra::extract::CookieJar::new().add(session.to_cookie()),
             [(
                 HeaderName::from_static("hx-redirect"),
                 HeaderValue::from_str(&params.next).unwrap_or_else(|err| {

--- a/src/web/auth.rs
+++ b/src/web/auth.rs
@@ -15,7 +15,7 @@ use crate::{
     AuthlyCtx,
 };
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct QueryParams {
     next: String,
 }
@@ -103,7 +103,14 @@ pub async fn login(
             CookieJar::new().add(session.to_cookie()),
             [(
                 HeaderName::from_static("hx-redirect"),
-                HeaderValue::from_str(&params.next).unwrap(),
+                HeaderValue::from_str(&params.next).unwrap_or_else(|err| {
+                    warn!(
+                        ?err,
+                        ?params,
+                        "client tried to fool us with a misformatted redirect url"
+                    );
+                    HeaderValue::from_static("")
+                }),
             )],
         )
             .into_response(),


### PR DESCRIPTION
Removes JSON APIs from the web login flow, and thereby custom JS script. When this is fully htmx-managed, it will be easier to integrate with OAuth, etc.

It now also displays an error message when login fails.