### PR TITLE
Webauthn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: taiki-e/install-action@protoc
       - run: cargo fmt --all -- --check
       - run: cargo deny check all
-      - run: cargo clippy --workspace
+      - run: cargo clippy --all-targets
 
   authly-test:
     # Runs the tests of the `authly` crate, not the end2end tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+checksum = "310c9bcae737a48ef5cdee3174184e6d548b292739ede61a1f955ef76a738861"
 dependencies = [
  "brotli",
  "futures-core",
@@ -348,7 +348,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "mimalloc",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "openraft",
  "openssl",
@@ -370,6 +370,7 @@ dependencies = [
  "tower-server",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -506,6 +507,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
  "webauthn-rs",
  "x509-parser",
  "zeroize",
@@ -623,6 +625,9 @@ dependencies = [
  "tonic",
  "tower-server",
  "tracing",
+ "uuid",
+ "webauthn-authenticator-rs",
+ "webauthn-rs-proto",
  "wiremock",
 ]
 
@@ -694,7 +699,6 @@ dependencies = [
  "authly-domain",
  "authly-test",
  "authly-web",
- "rusqlite",
  "tokio",
  "tower-server",
  "tracing",
@@ -981,7 +985,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
  "itertools 0.10.5",
@@ -997,6 +1001,12 @@ dependencies = [
  "syn 2.0.98",
  "which",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1150,12 +1160,11 @@ checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.12+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ebc2f1a417f01e1da30ef264ee86ae31d2dcd2d603ea283d3c244a883ca2a9"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -1223,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1233,7 +1242,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -2114,7 +2123,7 @@ dependencies = [
  "hyper-util",
  "lazy_static",
  "lz4-sys",
- "num-derive",
+ "num-derive 0.4.2",
  "num-traits",
  "openraft",
  "reqwest",
@@ -2996,6 +3005,17 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
@@ -3111,7 +3131,7 @@ version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3801,7 +3821,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "chrono",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
@@ -3894,7 +3914,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4057,7 +4077,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -4070,7 +4090,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -4109,6 +4129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+dependencies = [
  "serde",
 ]
 
@@ -4584,6 +4613,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4723,7 +4753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "base64 0.22.1",
- "bitflags",
+ "bitflags 2.8.0",
  "bytes",
  "http",
  "http-body",
@@ -4878,6 +4908,15 @@ name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-xid"
@@ -5137,6 +5176,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "webauthn-authenticator-rs"
+version = "0.5.1"
+source = "git+https://github.com/protojour/webauthn-rs.git?branch=without-openssl-build-dependency#06bd97250a5d680333f7841864caba40a35a0673"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.21.7",
+ "base64urlsafedata 0.5.1 (git+https://github.com/protojour/webauthn-rs.git?branch=without-openssl-build-dependency)",
+ "bitflags 1.3.2",
+ "futures",
+ "hex",
+ "nom",
+ "num-derive 0.3.3",
+ "num-traits",
+ "openssl",
+ "serde",
+ "serde_bytes",
+ "serde_cbor_2",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "unicode-normalization",
+ "url",
+ "uuid",
+ "webauthn-rs-core",
+ "webauthn-rs-proto",
+]
+
+[[package]]
 name = "webauthn-rs"
 version = "0.5.1"
 source = "git+https://github.com/protojour/webauthn-rs.git?branch=without-openssl-build-dependency#06bd97250a5d680333f7841864caba40a35a0673"
@@ -5257,6 +5326,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"
@@ -5409,7 +5484,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -5562,9 +5637,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
+version = "2.0.14+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,7 @@ dependencies = [
  "hexhex",
  "http",
  "indexmap 2.7.1",
+ "indoc",
  "itertools 0.14.0",
  "maud",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serde_plain",
  "serde_urlencoded",
  "test-log",
  "thiserror 2.0.11",
@@ -4182,6 +4183,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "openraft",
+ "openssl",
  "rand",
  "rcgen 0.13.2 (git+https://github.com/rustls/rcgen.git)",
  "reqwest",
@@ -505,6 +506,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "webauthn-rs",
  "x509-parser",
  "zeroize",
 ]
@@ -944,6 +946,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "base64urlsafedata"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f0ad38ce7fbed55985ad5b2197f05cff8324ee6eb6638304e78f0108fae56c"
+dependencies = [
+ "base64 0.21.7",
+ "paste",
+ "serde",
+]
+
+[[package]]
+name = "base64urlsafedata"
+version = "0.5.1"
+source = "git+https://github.com/protojour/webauthn-rs.git?branch=without-openssl-build-dependency#06bd97250a5d680333f7841864caba40a35a0673"
+dependencies = [
+ "base64 0.21.7",
+ "paste",
+ "serde",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,7 +1260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 2.4.1",
 ]
 
 [[package]]
@@ -1322,6 +1345,23 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "compact_jwt"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bbab6445446e8d0b07468a01d0bfdae15879de5c440c5e47ae4ae0e18a1fba"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex",
+ "openssl",
+ "serde",
+ "serde_json",
+ "tracing",
+ "url",
+ "uuid",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -1737,6 +1777,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +1966,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -3045,10 +3106,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-src"
+version = "300.4.2+3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+dependencies = [
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -4004,6 +4113,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor_2"
+version = "0.12.0-dev"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46d75f449e01f1eddbe9b00f432d616fbbd899b809c837d0fbc380496a0dd55"
+dependencies = [
+ "half 1.8.3",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4797,6 +4916,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -5002,6 +5122,69 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webauthn-attestation-ca"
+version = "0.5.1"
+source = "git+https://github.com/protojour/webauthn-rs.git?branch=without-openssl-build-dependency#06bd97250a5d680333f7841864caba40a35a0673"
+dependencies = [
+ "base64urlsafedata 0.5.1 (git+https://github.com/protojour/webauthn-rs.git?branch=without-openssl-build-dependency)",
+ "openssl",
+ "serde",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "webauthn-rs"
+version = "0.5.1"
+source = "git+https://github.com/protojour/webauthn-rs.git?branch=without-openssl-build-dependency#06bd97250a5d680333f7841864caba40a35a0673"
+dependencies = [
+ "base64urlsafedata 0.5.1 (git+https://github.com/protojour/webauthn-rs.git?branch=without-openssl-build-dependency)",
+ "serde",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-rs-core",
+]
+
+[[package]]
+name = "webauthn-rs-core"
+version = "0.5.1"
+source = "git+https://github.com/protojour/webauthn-rs.git?branch=without-openssl-build-dependency#06bd97250a5d680333f7841864caba40a35a0673"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata 0.5.1 (git+https://github.com/protojour/webauthn-rs.git?branch=without-openssl-build-dependency)",
+ "compact_jwt",
+ "der-parser",
+ "hex",
+ "nom",
+ "openssl",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "serde_cbor_2",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "uuid",
+ "webauthn-attestation-ca",
+ "webauthn-rs-proto",
+ "x509-parser",
+]
+
+[[package]]
+name = "webauthn-rs-proto"
+version = "0.5.1"
+source = "git+https://github.com/protojour/webauthn-rs.git?branch=without-openssl-build-dependency#06bd97250a5d680333f7841864caba40a35a0673"
+dependencies = [
+ "base64 0.21.7",
+ "base64urlsafedata 0.5.1 (git+https://github.com/protojour/webauthn-rs.git?branch=without-openssl-build-dependency)",
+ "serde",
+ "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
     "lib/authly-web",
     "lib/authly-webstatic",
 ]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 version = "0.0.0"
@@ -43,3 +43,4 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
 ] }
 tower-server = "0.3.1"
+webauthn-rs = { git = "https://github.com/protojour/webauthn-rs.git", branch = "without-openssl-build-dependency" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,10 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
 ] }
 tower-server = "0.3.1"
-webauthn-rs = { git = "https://github.com/protojour/webauthn-rs.git", branch = "without-openssl-build-dependency" }
+webauthn-authenticator-rs = { git = "https://github.com/protojour/webauthn-rs.git", branch = "without-openssl-build-dependency", default-features = false, features = [
+    "softtoken",
+] }
+webauthn-rs = { git = "https://github.com/protojour/webauthn-rs.git", branch = "without-openssl-build-dependency", features = [
+    "danger-allow-state-serialisation",
+] }
+webauthn-rs-proto = { git = "https://github.com/protojour/webauthn-rs.git", branch = "without-openssl-build-dependency" }

--- a/bin/authly-webdev/Cargo.toml
+++ b/bin/authly-webdev/Cargo.toml
@@ -20,7 +20,6 @@ authly-test = { path = "../../lib/authly-test" }
 authly-web = { path = "../../lib/authly-web" }
 
 anyhow = "1"
-rusqlite = { version = "0.33", features = ["bundled"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 tower-server = { workspace = true, features = ["signal"] }
 tracing = "0.1"

--- a/bin/authly-webdev/src/main.rs
+++ b/bin/authly-webdev/src/main.rs
@@ -1,5 +1,5 @@
 use authly_common::{id::ServiceId, mtls_server::PeerServiceEntity};
-use authly_domain::dev::IsDev;
+use authly_domain::{dev::IsDev, webauthn::WebauthnBuilder};
 use authly_test::{test_ctx::TestCtx, util::compile_and_apply_doc_dir};
 use tower_server::Scheme;
 use tracing::{info, level_filters::LevelFilter};
@@ -22,7 +22,16 @@ async fn main() -> anyhow::Result<()> {
         .persistent_db("./.local/webdev/authly.db")
         .await
         .supreme_instance()
-        .await;
+        .await
+        .with_webauthn(
+            WebauthnBuilder::new(
+                "localhost",
+                &format!("http://localhost:{PORT}").parse().unwrap(),
+            )
+            .unwrap()
+            .build()
+            .unwrap(),
+        );
 
     compile_and_apply_doc_dir("examples/demo".into(), &test_ctx)
         .await

--- a/bin/authly/Cargo.toml
+++ b/bin/authly/Cargo.toml
@@ -81,3 +81,4 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
     "fmt",
     "ansi",
 ] }
+uuid = "1"

--- a/bin/authly/Cargo.toml
+++ b/bin/authly/Cargo.toml
@@ -55,6 +55,8 @@ mimalloc = "0.1.43"
 num-derive = "0.4"
 num-traits = "0.2"
 openraft = { version = "0.9", default-features = false }
+# webauthn-rs on musl needs openssl/vendored:
+openssl = { version = "0.10", features = ["vendored"] }
 rand = "0.8"
 rcgen.workspace = true
 reqwest.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -109,6 +109,8 @@ skip = [
     "hashbrown",
     # FIXME: hexhex:
     "fallible-iterator",
+    # webauthn-rs git dependency:
+    "base64urlsafedata",
     # transitive/outdated:
     "base64",
     "getrandom",
@@ -137,6 +139,7 @@ unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 allow-git = [
+    "git+https://github.com/protojour/webauthn-rs.git?branch=without-openssl-build-dependency",
     "git+https://github.com/protojour/authly-lib.git",
     "git+https://github.com/sebadob/hiqlite.git",
     "git+https://github.com/rustls/rcgen.git",

--- a/lib/authly-db/src/lib.rs
+++ b/lib/authly-db/src/lib.rs
@@ -133,6 +133,16 @@ pub trait Row {
     }
 
     #[track_caller]
+    fn get_opt_datetime(&mut self, idx: &str) -> DbResult<Option<time::OffsetDateTime>> {
+        match self.get_opt_int(idx) {
+            Some(timestamp) => time::OffsetDateTime::from_unix_timestamp(timestamp)
+                .map(Some)
+                .map_err(|_| DbError::Timestamp),
+            None => Ok(None),
+        }
+    }
+
+    #[track_caller]
     fn get_id<T: Id128DynamicArrayConv>(&mut self, idx: &str) -> T {
         T::try_from_array_dynamic(&self.get_blob_array(idx)).unwrap()
     }

--- a/lib/authly-domain/Cargo.toml
+++ b/lib/authly-domain/Cargo.toml
@@ -59,3 +59,4 @@ tokio-util = { version = "0.7" }
 tracing = "0.1"
 x509-parser = "0.16"
 zeroize = "1.8"
+webauthn-rs.workspace = true

--- a/lib/authly-domain/Cargo.toml
+++ b/lib/authly-domain/Cargo.toml
@@ -57,6 +57,7 @@ time = "0.3"
 tokio = { version = "1", features = ["macros"] }
 tokio-util = { version = "0.7" }
 tracing = "0.1"
+uuid = "1"
 x509-parser = "0.16"
 zeroize = "1.8"
 webauthn-rs.workspace = true

--- a/lib/authly-domain/migrations/1_init.sql
+++ b/lib/authly-domain/migrations/1_init.sql
@@ -99,6 +99,8 @@ CREATE TABLE ent_passkey (
     eid BLOB NOT NULL,
     cred_id BLOB NOT NULL,
     pk_json BLOB NOT NULL,
+    created_at DATETIME NOT NULL,
+    last_used DATETIME,
 
     PRIMARY KEY (eid, cred_id)
 );

--- a/lib/authly-domain/migrations/1_init.sql
+++ b/lib/authly-domain/migrations/1_init.sql
@@ -95,6 +95,14 @@ CREATE TABLE ent_attr (
     PRIMARY KEY (eid, attr_key)
 );
 
+CREATE TABLE ent_passkey (
+    eid BLOB NOT NULL,
+    cred_id BLOB NOT NULL,
+    pk_json BLOB NOT NULL,
+
+    PRIMARY KEY (eid, cred_id)
+);
+
 CREATE TABLE ent_rel (
     dir_key INTEGER NOT NULL REFERENCES directory(key) DEFERRABLE INITIALLY DEFERRED,
     prop_key INTEGER NOT NULL REFERENCES prop(key) DEFERRABLE INITIALLY DEFERRED,

--- a/lib/authly-domain/src/ctx.rs
+++ b/lib/authly-domain/src/ctx.rs
@@ -103,24 +103,24 @@ pub trait WebAuthn {
         &self,
         persona_id: PersonaId,
         pk: PasskeyRegistration,
-    ) -> impl Future<Output = ()>;
+    ) -> impl Future<Output = ()> + Send;
 
     /// Yank passkey registration state out of the cache
     fn yank_passkey_registration(
         &self,
         persona_id: PersonaId,
-    ) -> impl Future<Output = Option<PasskeyRegistration>>;
+    ) -> impl Future<Output = Option<PasskeyRegistration>> + Send;
 
     /// Temporarily store passkey authentication state in the cache
     fn cache_passkey_authentication(
         &self,
         login_session_id: Uuid,
         value: (PersonaId, PasskeyAuthentication),
-    ) -> impl Future<Output = ()>;
+    ) -> impl Future<Output = ()> + Send;
 
     /// Yank passkey authentication state from the cache
     fn yank_passkey_authentication(
         &self,
         login_session_id: Uuid,
-    ) -> impl Future<Output = Option<(PersonaId, PasskeyAuthentication)>>;
+    ) -> impl Future<Output = Option<(PersonaId, PasskeyAuthentication)>> + Send;
 }

--- a/lib/authly-domain/src/extract/auth.rs
+++ b/lib/authly-domain/src/extract/auth.rs
@@ -6,7 +6,7 @@ use axum::{extract::FromRequestParts, response::IntoResponse, Extension, Request
 use http::{
     header::{self, LOCATION},
     request::Parts,
-    HeaderName, HeaderValue, StatusCode,
+    HeaderName, StatusCode,
 };
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
@@ -133,7 +133,7 @@ async fn redirect_to_login(parts: &mut Parts) -> anyhow::Result<axum::response::
         .to_string();
     let next_uri = utf8_percent_encode(&next_uri, NON_ALPHANUMERIC);
 
-    let auth_location = HeaderValue::from_str(&format!("{prefix}/auth?next={next_uri}"))?;
+    let auth_location = format!("{prefix}/auth?next={next_uri}");
 
     if parts.headers.contains_key("hx-request") {
         // do a HTMX full-page redirect

--- a/lib/authly-domain/src/extract/auth.rs
+++ b/lib/authly-domain/src/extract/auth.rs
@@ -16,7 +16,7 @@ use crate::{
     ctx::{GetDb, GetInstance},
     dev::IsDev,
     repo::entity_repo,
-    session::authenticate_session_cookie,
+    session::{authenticate_session_cookie, SESSION_COOKIE_NAME},
 };
 
 use super::base_uri::{ForwardedPrefix, ProxiedUri};
@@ -91,7 +91,7 @@ async fn verify<R: VerifyAuthlyRole>(
 
         let jar = cookie_jar(&parts.headers);
         let session_cookie = jar
-            .get("session-cookie")
+            .get(SESSION_COOKIE_NAME)
             .ok_or((StatusCode::UNAUTHORIZED, "no session cookie (dev mode)"))?;
         let session = authenticate_session_cookie(ctx, session_cookie)
             .await

--- a/lib/authly-domain/src/lib.rs
+++ b/lib/authly-domain/src/lib.rs
@@ -16,6 +16,7 @@ pub mod extract;
 pub mod id;
 pub mod instance;
 pub mod login;
+pub mod login_session;
 pub mod migration;
 pub mod persona_directory;
 pub mod policy;
@@ -26,6 +27,7 @@ pub mod service;
 pub mod session;
 pub mod settings;
 pub mod tls;
+pub mod webauthn;
 
 #[derive(Clone, Copy, Serialize, Deserialize, Debug)]
 pub struct IsLeaderDb(pub bool);

--- a/lib/authly-domain/src/login_session.rs
+++ b/lib/authly-domain/src/login_session.rs
@@ -1,0 +1,43 @@
+//! A login session is a session valid during a login flow.
+//! It does not represent an authenticated user.
+
+use cookie::{Cookie, SameSite};
+use http::request::Parts;
+use uuid::Uuid;
+
+pub const LOGIN_COOKIE_NAME: &str = "authly-login";
+
+pub struct LoginSession(pub Uuid);
+
+impl LoginSession {
+    pub fn to_cookie(&self) -> Cookie<'static> {
+        let mut cookie = Cookie::new(LOGIN_COOKIE_NAME, format!("{}", hexhex::hex(&self.0)));
+        cookie.set_path("/");
+        // cookie.set_secure(true);
+        cookie.set_http_only(true);
+        cookie.set_same_site(SameSite::Strict);
+        cookie
+    }
+}
+
+#[axum::async_trait]
+impl<S: Send + Sync> axum::extract::FromRequestParts<S> for LoginSession {
+    type Rejection = ();
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let jar = axum_extra::extract::CookieJar::from_request_parts(parts, state)
+            .await
+            .unwrap();
+
+        fn read_cookie(jar: axum_extra::extract::CookieJar) -> Option<LoginSession> {
+            let cookie = jar.get(LOGIN_COOKIE_NAME)?;
+            let id = Uuid::parse_str(cookie.value_trimmed()).ok()?;
+            Some(LoginSession(id))
+        }
+
+        match read_cookie(jar) {
+            Some(session) => Ok(session),
+            None => Ok(LoginSession(Uuid::new_v4())),
+        }
+    }
+}

--- a/lib/authly-domain/src/policy/compiler/expr.rs
+++ b/lib/authly-domain/src/policy/compiler/expr.rs
@@ -53,6 +53,7 @@ impl Expr {
         Self::Or(Box::new(lhs), Box::new(rhs))
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn not(expr: Expr) -> Self {
         Self::Not(Box::new(expr))
     }

--- a/lib/authly-domain/src/repo/mod.rs
+++ b/lib/authly-domain/src/repo/mod.rs
@@ -9,6 +9,7 @@ pub mod policy_repo;
 pub mod service_repo;
 pub mod session_repo;
 pub mod settings_repo;
+pub mod webauthn_repo;
 
 #[derive(Debug)]
 pub struct Identified<I, D>(pub I, pub D);

--- a/lib/authly-domain/src/repo/webauthn_repo.rs
+++ b/lib/authly-domain/src/repo/webauthn_repo.rs
@@ -1,20 +1,24 @@
 use authly_common::id::{PersonaId, PropId};
 use authly_db::{param::ToBlob, params, Db, DbError, DbResult, TryFromRow};
 use indoc::indoc;
-use webauthn_rs::prelude::Passkey;
+use webauthn_rs::prelude::{CredentialID, Passkey};
 
 pub struct PasskeyRow {
     pub eid: PersonaId,
     pub passkey: Passkey,
+    pub created: time::OffsetDateTime,
+    pub last_used: Option<time::OffsetDateTime>,
 }
 
 impl TryFromRow for PasskeyRow {
-    type Error = serde_json::Error;
+    type Error = anyhow::Error;
 
     fn try_from_row(row: &mut impl authly_db::Row) -> Result<Self, Self::Error> {
         Ok(PasskeyRow {
             eid: row.get_id("eid"),
             passkey: serde_json::from_str(&row.get_text("pk_json"))?,
+            created: row.get_datetime("created_at")?,
+            last_used: row.get_opt_datetime("last_used")?,
         })
     }
 }
@@ -27,7 +31,7 @@ pub async fn list_passkeys_by_entity_ident(
     deps.query_filter_map::<PasskeyRow>(
         indoc! {
             "
-            SELECT pk.eid, pk.pk_json FROM ent_passkey pk
+            SELECT pk.eid, pk.pk_json, pk.created_at, pk.last_used FROM ent_passkey pk
             JOIN obj_ident i ON i.obj_id = pk.eid
             WHERE i.prop_key = (SELECT key FROM prop WHERE id = $1)
                 AND i.fingerprint = $2
@@ -44,7 +48,7 @@ pub async fn list_passkeys_by_entity_id(
     eid: PersonaId,
 ) -> DbResult<Vec<PasskeyRow>> {
     deps.query_filter_map::<PasskeyRow>(
-        "SELECT pk.eid, pk.pk_json FROM ent_passkey pk WHERE pk.eid = $1".into(),
+        "SELECT eid, pk_json, created_at, last_used FROM ent_passkey pk WHERE pk.eid = $1".into(),
         params!(eid.to_blob()),
     )
     .await
@@ -54,14 +58,16 @@ pub async fn insert_passkey(
     deps: &impl Db,
     persona_id: PersonaId,
     passkey: &Passkey,
+    now: time::OffsetDateTime,
 ) -> DbResult<()> {
     deps.execute(
-        "INSERT INTO ent_passkey (eid, cred_id, pk_json) VALUES ($1, $2, $3)".into(),
+        "INSERT INTO ent_passkey (eid, cred_id, pk_json, created_at, last_used) VALUES ($1, $2, $3, $4, $4)".into(),
         params!(
             persona_id.to_blob(),
             passkey.cred_id().to_vec(),
             serde_json::to_string(passkey)
-                .map_err(|err| { DbError::Other(format!("{err:?}").into()) })?
+                .map_err(|err| { DbError::Other(format!("{err:?}").into()) })?,
+            now.unix_timestamp()
         ),
     )
     .await?;
@@ -72,15 +78,44 @@ pub async fn update_passkey(
     deps: &impl Db,
     persona_id: PersonaId,
     passkey: &Passkey,
+    now: time::OffsetDateTime,
 ) -> DbResult<()> {
     let row_count = deps
         .execute(
-            "UPDATE ent_passkey SET pk_json = $1 WHERE eid = $2 AND cred_id = $3".into(),
+            "UPDATE ent_passkey SET pk_json = $1, last_used = $2 WHERE eid = $3 AND cred_id = $4"
+                .into(),
             params!(
                 serde_json::to_string(passkey)
                     .map_err(|err| { DbError::Other(format!("{err:?}").into()) })?,
+                now.unix_timestamp(),
                 persona_id.to_blob(),
                 passkey.cred_id().to_vec()
+            ),
+        )
+        .await?;
+
+    if row_count != 1 {
+        return Err(DbError::Other(
+            format!("passkey not updated (row_count = {row_count})").into(),
+        ));
+    }
+
+    Ok(())
+}
+
+pub async fn update_passkey_last_used(
+    deps: &impl Db,
+    persona_id: PersonaId,
+    credential_id: &CredentialID,
+    now: time::OffsetDateTime,
+) -> DbResult<()> {
+    let row_count = deps
+        .execute(
+            "UPDATE ent_passkey SET last_used = $1 WHERE eid = $2 AND cred_id = $3".into(),
+            params!(
+                now.unix_timestamp(),
+                persona_id.to_blob(),
+                credential_id.to_vec()
             ),
         )
         .await?;

--- a/lib/authly-domain/src/repo/webauthn_repo.rs
+++ b/lib/authly-domain/src/repo/webauthn_repo.rs
@@ -1,0 +1,95 @@
+use authly_common::id::{PersonaId, PropId};
+use authly_db::{param::ToBlob, params, Db, DbError, DbResult, TryFromRow};
+use indoc::indoc;
+use webauthn_rs::prelude::Passkey;
+
+pub struct PasskeyRow {
+    pub eid: PersonaId,
+    pub passkey: Passkey,
+}
+
+impl TryFromRow for PasskeyRow {
+    type Error = serde_json::Error;
+
+    fn try_from_row(row: &mut impl authly_db::Row) -> Result<Self, Self::Error> {
+        Ok(PasskeyRow {
+            eid: row.get_id("eid"),
+            passkey: serde_json::from_str(&row.get_text("pk_json"))?,
+        })
+    }
+}
+
+pub async fn list_passkeys_by_entity_ident(
+    deps: &impl Db,
+    ident_prop_id: PropId,
+    ident_fingerprint: &[u8],
+) -> DbResult<Vec<PasskeyRow>> {
+    deps.query_filter_map::<PasskeyRow>(
+        indoc! {
+            "
+            SELECT pk.eid, pk.pk_json FROM ent_passkey pk
+            JOIN obj_ident i ON i.obj_id = pk.eid
+            WHERE i.prop_key = (SELECT key FROM prop WHERE id = $1)
+                AND i.fingerprint = $2
+            ",
+        }
+        .into(),
+        params!(ident_prop_id.to_blob(), ident_fingerprint.to_blob()),
+    )
+    .await
+}
+
+pub async fn list_passkeys_by_entity_id(
+    deps: &impl Db,
+    eid: PersonaId,
+) -> DbResult<Vec<PasskeyRow>> {
+    deps.query_filter_map::<PasskeyRow>(
+        "SELECT pk.eid, pk.pk_json FROM ent_passkey pk WHERE pk.eid = $1".into(),
+        params!(eid.to_blob()),
+    )
+    .await
+}
+
+pub async fn insert_passkey(
+    deps: &impl Db,
+    persona_id: PersonaId,
+    passkey: &Passkey,
+) -> DbResult<()> {
+    deps.execute(
+        "INSERT INTO ent_passkey (eid, cred_id, pk_json) VALUES ($1, $2, $3)".into(),
+        params!(
+            persona_id.to_blob(),
+            passkey.cred_id().to_vec(),
+            serde_json::to_string(passkey)
+                .map_err(|err| { DbError::Other(format!("{err:?}").into()) })?
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+pub async fn update_passkey(
+    deps: &impl Db,
+    persona_id: PersonaId,
+    passkey: &Passkey,
+) -> DbResult<()> {
+    let row_count = deps
+        .execute(
+            "UPDATE ent_passkey SET pk_json = $1 WHERE eid = $2 AND cred_id = $3".into(),
+            params!(
+                serde_json::to_string(passkey)
+                    .map_err(|err| { DbError::Other(format!("{err:?}").into()) })?,
+                persona_id.to_blob(),
+                passkey.cred_id().to_vec()
+            ),
+        )
+        .await?;
+
+    if row_count != 1 {
+        return Err(DbError::Other(
+            format!("passkey not updated (row_count = {row_count})").into(),
+        ));
+    }
+
+    Ok(())
+}

--- a/lib/authly-domain/src/webauthn.rs
+++ b/lib/authly-domain/src/webauthn.rs
@@ -1,0 +1,141 @@
+use authly_common::id::PersonaId;
+use authly_db::DbError;
+use hexhex::Hex;
+use http::Uri;
+use thiserror::Error;
+use tracing::info;
+use uuid::Uuid;
+pub use webauthn_rs::prelude::{
+    CreationChallengeResponse, Passkey, PasskeyAuthentication, PasskeyRegistration,
+    PublicKeyCredential, RegisterPublicKeyCredential, RequestChallengeResponse, Webauthn,
+    WebauthnBuilder,
+};
+
+use crate::{
+    ctx::{GetBuiltins, GetDb, GetDecryptedDeks, WebAuthn},
+    id::BuiltinProp,
+    repo::webauthn_repo,
+    session::{init_session, Session},
+};
+
+#[derive(Error, Debug)]
+pub enum WebauthnError {
+    #[error("webauthn not supported")]
+    NotSupported,
+    #[error("db")]
+    Db(#[from] DbError),
+    #[error("webauthn")]
+    Webauthn(#[from] webauthn_rs::prelude::WebauthnError),
+    #[error("no session")]
+    NoSession,
+}
+
+pub async fn webauthn_start_registration(
+    deps: &impl WebAuthn,
+    public_uri: &Uri,
+    persona_id: PersonaId,
+    user_name: &str,
+) -> Result<CreationChallengeResponse, WebauthnError> {
+    let uuid = Uuid::from_bytes(persona_id.to_raw_array());
+    let already_registered_credentials = vec![];
+
+    let (challenge_response, passkey_registration) =
+        deps.get_webauthn(public_uri)?.start_passkey_registration(
+            uuid,
+            user_name,
+            user_name,
+            Some(already_registered_credentials),
+        )?;
+
+    deps.cache_passkey_registration(persona_id, passkey_registration)
+        .await;
+
+    Ok(challenge_response)
+}
+
+pub async fn webauthn_finish_registration(
+    deps: &(impl GetDb + WebAuthn),
+    public_uri: &Uri,
+    persona_id: PersonaId,
+    body: RegisterPublicKeyCredential,
+) -> Result<(), WebauthnError> {
+    let Some(passkey_registration) = deps.yank_passkey_registration(persona_id).await else {
+        return Err(WebauthnError::NoSession);
+    };
+
+    let passkey = deps
+        .get_webauthn(public_uri)?
+        .finish_passkey_registration(&body, &passkey_registration)?;
+
+    webauthn_repo::insert_passkey(deps.get_db(), persona_id, &passkey).await?;
+
+    Ok(())
+}
+
+pub async fn webauthn_start_authentication(
+    deps: &(impl GetDb + WebAuthn + GetDecryptedDeks),
+    public_uri: &Uri,
+    login_session_id: Uuid,
+    username: &str,
+) -> Result<RequestChallengeResponse, WebauthnError> {
+    let ident_fingerprint = {
+        let deks = deps.get_decrypted_deks();
+        let dek = deks.get(BuiltinProp::Username.into()).unwrap();
+
+        dek.fingerprint(username.as_bytes())
+    };
+
+    let passkey_rows = webauthn_repo::list_passkeys_by_entity_ident(
+        deps.get_db(),
+        BuiltinProp::Username.into(),
+        &ident_fingerprint,
+    )
+    .await?;
+
+    let eid = passkey_rows.first().map(|row| row.eid);
+    let passkeys: Vec<Passkey> = passkey_rows.into_iter().map(|row| row.passkey).collect();
+
+    let (challenge_response, passkey_authentication) = deps
+        .get_webauthn(public_uri)?
+        .start_passkey_authentication(&passkeys)?;
+
+    // If there were any passkeys for the user, store the authentication session in the cache.
+    // This helps concealing internal state when the username is not associated with any passkeys..
+    if let Some(persona_id) = eid {
+        deps.cache_passkey_authentication(login_session_id, (persona_id, passkey_authentication))
+            .await;
+    }
+
+    Ok(challenge_response)
+}
+
+pub async fn webauthn_finish_authentication(
+    deps: &(impl GetDb + WebAuthn + GetBuiltins),
+    public_uri: &Uri,
+    login_session_id: Uuid,
+    credential: PublicKeyCredential,
+) -> Result<(PersonaId, Session), WebauthnError> {
+    let Some((persona_id, passkey_authentication)) =
+        deps.yank_passkey_authentication(login_session_id).await
+    else {
+        return Err(WebauthnError::NoSession);
+    };
+
+    let auth_result = deps
+        .get_webauthn(public_uri)?
+        .finish_passkey_authentication(&credential, &passkey_authentication)?;
+
+    for mut row in webauthn_repo::list_passkeys_by_entity_id(deps.get_db(), persona_id).await? {
+        if row.passkey.update_credential(&auth_result) == Some(true) {
+            info!(
+                "auth successful, updating passkey {}",
+                Hex::new(row.passkey.cred_id())
+            );
+            webauthn_repo::update_passkey(deps.get_db(), persona_id, &row.passkey).await?;
+        }
+    }
+
+    let session = init_session(deps, persona_id.upcast()).await?;
+
+    Ok((persona_id, session))
+}

--- a/lib/authly-domain/src/webauthn.rs
+++ b/lib/authly-domain/src/webauthn.rs
@@ -12,7 +12,7 @@ pub use webauthn_rs::prelude::{
 };
 
 use crate::{
-    ctx::{GetBuiltins, GetDb, GetDecryptedDeks, WebAuthn},
+    ctx::{GetDb, GetDecryptedDeks, WebAuthn},
     encryption::CryptoError,
     id::BuiltinProp,
     repo::{crypto_repo, webauthn_repo},
@@ -124,7 +124,7 @@ pub async fn webauthn_start_authentication(
 }
 
 pub async fn webauthn_finish_authentication(
-    deps: &(impl GetDb + WebAuthn + GetBuiltins),
+    deps: &(impl GetDb + WebAuthn),
     public_uri: &Uri,
     login_session_id: Uuid,
     credential: PublicKeyCredential,

--- a/lib/authly-sqlite/Cargo.toml
+++ b/lib/authly-sqlite/Cargo.toml
@@ -16,6 +16,6 @@ doctest = false
 [dependencies]
 authly-db = { path = "../authly-db" }
 deadpool = "0.12"
-rusqlite = "0.33"
+rusqlite = { version = "0.33", features = ["bundled"] }
 tokio = { version = "1", features = ["macros"] }
 tracing = "0.1"

--- a/lib/authly-test/Cargo.toml
+++ b/lib/authly-test/Cargo.toml
@@ -25,6 +25,7 @@ authly-common = { workspace = true, features = [
 anyhow = "1"
 arc-swap = "1.7"
 axum = { version = "0.7", features = ["macros"] }
+http = "1"
 indexmap = "2.7"
 indoc = "2"
 rcgen.workspace = true
@@ -39,6 +40,7 @@ tokio-util = { version = "0.7" }
 tonic = { version = "0.12", default-features = false }
 tower-server.workspace = true
 tracing = "0.1"
+uuid = "1"
 
 [dev-dependencies]
 authly-service = { path = "../authly-service" }
@@ -50,12 +52,13 @@ criterion = { version = "0.5", default-features = false }
 fnv = "1"
 futures-util = "0.3"
 hexhex = "1"
-http = "1"
 hyper-util = { version = "0.1", features = ["tokio", "server", "http2"] }
 itertools = "0.14"
 serde_json = "1"
 test-log = { version = "0.2", features = ["trace"] }
 tokio-rustls = "0.26"
+webauthn-authenticator-rs.workspace = true
+webauthn-rs-proto.workspace = true
 wiremock = "0.6.2"
 
 [[bench]]

--- a/lib/authly-test/src/test_ctx.rs
+++ b/lib/authly-test/src/test_ctx.rs
@@ -371,10 +371,7 @@ impl KubernetesConfig for TestCtx {
 }
 
 impl WebAuthn for TestCtx {
-    fn get_webauthn(&self, public_uri: &Uri) -> Result<Arc<Webauthn>, WebauthnError> {
-        if public_uri != "http://localhost/" {
-            panic!("test context should use http://localhost/");
-        }
+    fn get_webauthn(&self, _public_uri: &Uri) -> Result<Arc<Webauthn>, WebauthnError> {
         self.webauthn.clone().ok_or(WebauthnError::NotSupported)
     }
 

--- a/lib/authly-test/src/test_ctx.rs
+++ b/lib/authly-test/src/test_ctx.rs
@@ -1,4 +1,6 @@
 use std::{
+    any::Any,
+    collections::HashMap,
     fs,
     future::Future,
     path::PathBuf,
@@ -6,7 +8,7 @@ use std::{
 };
 
 use arc_swap::ArcSwap;
-use authly_common::id::ServiceId;
+use authly_common::id::{PersonaId, ServiceId};
 use authly_db::{params, Db, FromRow};
 use authly_domain::{
     builtins::Builtins,
@@ -18,7 +20,7 @@ use authly_domain::{
     ctx::{
         ClusterBus, Directories, GetBuiltins, GetDb, GetDecryptedDeks, GetHttpClient, GetInstance,
         HostsConfig, KubernetesConfig, LoadInstance, RedistributeCertificates, ServiceBus,
-        SetInstance,
+        SetInstance, WebAuthn,
     },
     directory::PersonaDirectory,
     encryption::{gen_prop_deks, DecryptedDeks, DecryptedMaster},
@@ -26,13 +28,16 @@ use authly_domain::{
     migration::Migrations,
     repo::{crypto_repo, init_repo},
     tls::{AuthlyCert, AuthlyCertKind},
+    webauthn::{PasskeyAuthentication, PasskeyRegistration, Webauthn, WebauthnError},
     IsLeaderDb,
 };
 use authly_sqlite::{SqlitePool, Storage};
+use http::Uri;
 use indexmap::IndexMap;
 use indoc::indoc;
 use tokio_util::sync::{CancellationToken, DropGuard};
 use tracing::info;
+use uuid::Uuid;
 
 /// The TestCtx allows writing tests that don't require the whole app running.
 /// E.g. it supports an in-memory database.
@@ -44,7 +49,9 @@ pub struct TestCtx {
     deks: Arc<ArcSwap<DecryptedDeks>>,
     svc_event_dispatcher: ServiceEventDispatcher,
     persona_directories: IndexMap<String, PersonaDirectory>,
+    webauthn: Option<Arc<Webauthn>>,
 
+    cache: Arc<Mutex<HashMap<String, Box<dyn Any + Send>>>>,
     cluster_message_log: Arc<Mutex<Vec<ClusterMessage>>>,
 
     /// When all TestCtx clones go out of scope,
@@ -65,6 +72,8 @@ impl TestCtx {
             deks: Default::default(),
             svc_event_dispatcher: ServiceEventDispatcher::new(cancel.clone()),
             persona_directories: Default::default(),
+            cache: Arc::new(Mutex::new(HashMap::new())),
+            webauthn: None,
             cluster_message_log: Default::default(),
             cancel_guard: Arc::new(cancel.drop_guard()),
         }
@@ -205,6 +214,11 @@ impl TestCtx {
         self
     }
 
+    pub fn with_webauthn(mut self, webauthn: Webauthn) -> Self {
+        self.webauthn = Some(Arc::new(webauthn));
+        self
+    }
+
     pub fn get_decrypted_deks(&self) -> Arc<DecryptedDeks> {
         self.deks.as_ref().load_full()
     }
@@ -216,6 +230,24 @@ impl TestCtx {
     #[track_caller]
     fn instance(&self) -> &ArcSwap<AuthlyInstance> {
         self.instance.as_ref().expect("TestCtx has no instance")
+    }
+
+    fn cache_insert<T: Any + Send>(&self, key: String, value: T) {
+        let mut cache = self.cache.lock().unwrap();
+        cache.insert(key, Box::new(value));
+    }
+
+    #[expect(unused)]
+    fn cache_get<T: Any + Clone>(&self, key: &str) -> Option<T> {
+        let mut cache = self.cache.lock().unwrap();
+        let value = cache.get(key)?;
+        Some(value.downcast_ref::<T>().unwrap().clone())
+    }
+
+    fn cache_yank<T: Any + Clone>(&self, key: &str) -> Option<T> {
+        let mut cache = self.cache.lock().unwrap();
+        let value = cache.remove(key)?;
+        Some(value.downcast_ref::<T>().unwrap().clone())
     }
 }
 
@@ -335,6 +367,45 @@ impl HostsConfig for TestCtx {
 impl KubernetesConfig for TestCtx {
     fn authly_local_k8s_namespace(&self) -> &str {
         "default"
+    }
+}
+
+impl WebAuthn for TestCtx {
+    fn get_webauthn(&self, public_uri: &Uri) -> Result<Arc<Webauthn>, WebauthnError> {
+        if public_uri != "http://localhost/" {
+            panic!("test context should use http://localhost/");
+        }
+        self.webauthn.clone().ok_or(WebauthnError::NotSupported)
+    }
+
+    async fn cache_passkey_registration(
+        &self,
+        persona_id: authly_common::id::PersonaId,
+        pk: PasskeyRegistration,
+    ) {
+        self.cache_insert(format!("pk-reg-{persona_id}"), pk);
+    }
+
+    async fn yank_passkey_registration(
+        &self,
+        persona_id: authly_common::id::PersonaId,
+    ) -> Option<PasskeyRegistration> {
+        self.cache_yank(&format!("pk-reg-{persona_id}"))
+    }
+
+    async fn cache_passkey_authentication(
+        &self,
+        login_session_id: Uuid,
+        value: (PersonaId, PasskeyAuthentication),
+    ) {
+        self.cache_insert(format!("pk-auth-{login_session_id}"), value);
+    }
+
+    async fn yank_passkey_authentication(
+        &self,
+        login_session_id: uuid::Uuid,
+    ) -> Option<(PersonaId, PasskeyAuthentication)> {
+        self.cache_yank(&format!("pk-auth-{login_session_id}"))
     }
 }
 

--- a/lib/authly-test/src/tests/mod.rs
+++ b/lib/authly-test/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod test_document;
 mod test_metadata;
 mod test_tls;
 mod test_ultradb;
+mod test_webauthn;
 
 #[test]
 fn directory_changed_serde() {

--- a/lib/authly-test/src/tests/test_webauthn.rs
+++ b/lib/authly-test/src/tests/test_webauthn.rs
@@ -1,0 +1,162 @@
+use authly_common::id::PersonaId;
+use authly_domain::webauthn::{self, Webauthn, WebauthnBuilder};
+use hexhex::hex_literal;
+use http::Uri;
+use reqwest::Url;
+use uuid::Uuid;
+use webauthn_authenticator_rs::{softtoken::SoftToken, AuthenticatorBackend};
+
+use crate::{test_ctx::TestCtx, util::compile_and_apply_doc_dir};
+
+const TIMEOUT_MS: u32 = 1000;
+
+async fn test_ctx_with_webauthn(webauthn: Webauthn) -> TestCtx {
+    TestCtx::new()
+        .inmemory_db()
+        .await
+        .supreme_instance()
+        .await
+        .with_webauthn(webauthn)
+}
+
+fn webauthn_localhost() -> Webauthn {
+    WebauthnBuilder::new("localhost", &localhost())
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+fn localhost() -> Url {
+    "http://localhost".parse().unwrap()
+}
+
+fn localhost_uri() -> Uri {
+    "http://localhost".parse().unwrap()
+}
+
+fn new_soft_token() -> SoftToken {
+    let falsify_uv = true;
+    SoftToken::new(falsify_uv).unwrap().0
+}
+
+const TESTUSER: &str = "testuser";
+const TESTUSER_ID: PersonaId =
+    PersonaId::from_raw_array(hex_literal!("0fbcd73e1a884424a1615c3c3fdeebec"));
+
+#[test_log::test(tokio::test)]
+async fn test_webauthn_happy_path() {
+    let ctx = test_ctx_with_webauthn(webauthn_localhost()).await;
+    compile_and_apply_doc_dir("../../examples/demo".into(), &ctx)
+        .await
+        .unwrap();
+
+    let mut token = new_soft_token();
+    // the username can be whatever:
+    register_token(TESTUSER_ID, &mut token, "whatever", &ctx).await;
+
+    let login_session_id = Uuid::new_v4();
+
+    let (persona_id, session) = {
+        let auth_challenge = webauthn::webauthn_start_authentication(
+            &ctx,
+            &localhost_uri(),
+            login_session_id,
+            TESTUSER,
+        )
+        .await
+        .unwrap();
+
+        let credential = token
+            .perform_auth(localhost(), auth_challenge.public_key, TIMEOUT_MS)
+            .unwrap();
+
+        webauthn::webauthn_finish_authentication(
+            &ctx,
+            &localhost_uri(),
+            login_session_id,
+            credential,
+        )
+        .await
+        .unwrap()
+    };
+
+    assert_eq!(persona_id, TESTUSER_ID);
+    assert_eq!(session.eid, TESTUSER_ID.upcast());
+}
+
+#[test_log::test(tokio::test)]
+async fn test_webauthn_invalid_username() {
+    let ctx = test_ctx_with_webauthn(webauthn_localhost()).await;
+    compile_and_apply_doc_dir("../../examples/demo".into(), &ctx)
+        .await
+        .unwrap();
+
+    let mut token = new_soft_token();
+    // the username can be whatever:
+    register_token(TESTUSER_ID, &mut token, "whatever", &ctx).await;
+
+    let error = {
+        let auth_challenge = webauthn::webauthn_start_authentication(
+            &ctx,
+            &localhost_uri(),
+            Uuid::new_v4(),
+            "username.incorrect",
+        )
+        .await
+        .unwrap();
+
+        token
+            .perform_auth(localhost(), auth_challenge.public_key, TIMEOUT_MS)
+            .unwrap_err()
+    };
+
+    assert_eq!(
+        "Internal",
+        format!("{error:?}"),
+        "the error message is bad, but proves login failed"
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn test_webauthn_unregistered_token() {
+    let ctx = test_ctx_with_webauthn(webauthn_localhost()).await;
+    compile_and_apply_doc_dir("../../examples/demo".into(), &ctx)
+        .await
+        .unwrap();
+
+    let auth_challenge =
+        webauthn::webauthn_start_authentication(&ctx, &&localhost_uri(), Uuid::new_v4(), TESTUSER)
+            .await
+            .unwrap();
+
+    let mut token = new_soft_token();
+    let error = token
+        .perform_auth(localhost(), auth_challenge.public_key, TIMEOUT_MS)
+        .unwrap_err();
+
+    assert_eq!(
+        "Internal",
+        format!("{error:?}"),
+        "the error message is bad, but proves login failed"
+    );
+}
+
+async fn register_token(
+    persona_id: PersonaId,
+    token: &mut SoftToken,
+    user_name: &str,
+    ctx: &TestCtx,
+) {
+    let reg_challenge =
+        webauthn::webauthn_start_registration(ctx, &localhost_uri(), persona_id, user_name)
+            .await
+            .unwrap();
+
+    let credential = token
+        .perform_register(localhost(), reg_challenge.public_key, TIMEOUT_MS)
+        .unwrap();
+
+    webauthn::webauthn_finish_registration(ctx, &localhost_uri(), persona_id, credential)
+        .await
+        .unwrap();
+}

--- a/lib/authly-test/src/tests/test_webauthn.rs
+++ b/lib/authly-test/src/tests/test_webauthn.rs
@@ -52,7 +52,7 @@ async fn test_webauthn_happy_path() {
 
     let mut token = new_soft_token();
     // the username can be whatever:
-    register_token(TESTUSER_ID, &mut token, "whatever", &ctx).await;
+    register_token(TESTUSER_ID, &mut token, &ctx).await;
 
     let login_session_id = Uuid::new_v4();
 
@@ -93,7 +93,7 @@ async fn test_webauthn_invalid_username() {
 
     let mut token = new_soft_token();
     // the username can be whatever:
-    register_token(TESTUSER_ID, &mut token, "whatever", &ctx).await;
+    register_token(TESTUSER_ID, &mut token, &ctx).await;
 
     let error = {
         let auth_challenge = webauthn::webauthn_start_authentication(
@@ -125,7 +125,7 @@ async fn test_webauthn_unregistered_token() {
         .unwrap();
 
     let auth_challenge =
-        webauthn::webauthn_start_authentication(&ctx, &&localhost_uri(), Uuid::new_v4(), TESTUSER)
+        webauthn::webauthn_start_authentication(&ctx, &localhost_uri(), Uuid::new_v4(), TESTUSER)
             .await
             .unwrap();
 
@@ -141,16 +141,10 @@ async fn test_webauthn_unregistered_token() {
     );
 }
 
-async fn register_token(
-    persona_id: PersonaId,
-    token: &mut SoftToken,
-    user_name: &str,
-    ctx: &TestCtx,
-) {
-    let reg_challenge =
-        webauthn::webauthn_start_registration(ctx, &localhost_uri(), persona_id, user_name)
-            .await
-            .unwrap();
+async fn register_token(persona_id: PersonaId, token: &mut SoftToken, ctx: &TestCtx) {
+    let reg_challenge = webauthn::webauthn_start_registration(ctx, &localhost_uri(), persona_id)
+        .await
+        .unwrap();
 
     let credential = token
         .perform_register(localhost(), reg_challenge.public_key, TIMEOUT_MS)

--- a/lib/authly-web/Cargo.toml
+++ b/lib/authly-web/Cargo.toml
@@ -23,6 +23,7 @@ fnv = "1"
 hexhex = "1"
 http = "1"
 indexmap = "2.7"
+indoc = "2"
 itertools = "0.14"
 maud = { version = "0.26", features = ["axum"] }
 rand = "0.8"

--- a/lib/authly-web/Cargo.toml
+++ b/lib/authly-web/Cargo.toml
@@ -31,8 +31,10 @@ reqwest.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_urlencoded = "0.7"
+serde_plain = "1"
 tokio = { version = "1", features = ["macros"] }
 thiserror = "2"
+time = "0.3"
 tracing = "0.1"
 url = "2.5"
 
@@ -40,5 +42,4 @@ url = "2.5"
 authly-db = { path = "../authly-db" }
 authly-test = { path = "../authly-test" }
 test-log = { version = "0.2", features = ["trace"] }
-time = "0.3"
 wiremock = "0.6.2"

--- a/lib/authly-web/src/app.rs
+++ b/lib/authly-web/src/app.rs
@@ -40,6 +40,9 @@ fn render_app_tab(Htmx { prefix, .. }: &Htmx, tab: Markup, js: Option<String>) -
                 title { "Authly" }
                 script src={(prefix)"/static/vendor/htmx.min.js"} {}
                 script src={(prefix)"/static/vendor/base64.min.js"} {}
+                // The relative-time Web Component:
+                script type="module" src={(prefix)"/static/vendor/relative-time-element-bundle.js"} {}
+
                 link rel="shortcut icon" href={(prefix)"/static/favicon.svg"} type="image/svg+xml";
                 link rel="stylesheet" href={(prefix)"/static/vendor/pico.classless.min.css"};
                 link rel="stylesheet" href={(prefix)"/static/style.css"};
@@ -70,6 +73,10 @@ pub enum AppError {
     InvalidInput(anyhow::Error),
     #[error("internal: {0}")]
     Internal(anyhow::Error),
+    #[error("date format: {0}")]
+    TimeFormat(#[from] time::error::Format),
+    #[error("plain format: {0}")]
+    SerdePlain(#[from] serde_plain::Error),
 }
 
 impl IntoResponse for AppError {

--- a/lib/authly-web/src/app.rs
+++ b/lib/authly-web/src/app.rs
@@ -1,9 +1,6 @@
 use authly_domain::extract::auth::WebAuth;
 use axum::response::{IntoResponse, Response};
-use http::{
-    header::{InvalidHeaderValue, LOCATION},
-    HeaderValue, StatusCode,
-};
+use http::{header::LOCATION, StatusCode};
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 use tracing::warn;
 
@@ -23,7 +20,7 @@ pub async fn index(
         StatusCode::FOUND,
         [(
             if hx_request { HX_REDIRECT } else { LOCATION },
-            HeaderValue::from_str(&format!("{prefix}/tab/persona"))?,
+            format!("{prefix}/tab/persona"),
         )],
     )
         .into_response())
@@ -68,8 +65,6 @@ pub enum AppError {
     #[error("must be persona")]
     MustBePersona,
     #[error("invalid header value")]
-    InvalidHeaderValue(#[from] InvalidHeaderValue),
-    #[error("invalid input: {0}")]
     InvalidInput(anyhow::Error),
     #[error("internal: {0}")]
     Internal(anyhow::Error),

--- a/lib/authly-web/src/app/persona.rs
+++ b/lib/authly-web/src/app/persona.rs
@@ -12,7 +12,6 @@ use axum::{
     response::{IntoResponse, Response},
     Form,
 };
-use http::HeaderValue;
 use indoc::formatdoc;
 use maud::{html, Markup};
 use serde::Deserialize;
@@ -85,9 +84,9 @@ where
                         }
                     }
 
-                    div id="webauthnreg" {
-                        button hx-post={(prefix)"/tab/persona/webauthn/register_start"} hx-target="#webauthnreg" {
-                            "Register new WebAuthn token"
+                    div id="passkeyreg" {
+                        button hx-post={(prefix)"/tab/persona/webauthn/register_start"} hx-target="#passkeyreg" {
+                            "Register new Passkey"
                         }
                     }
                 }
@@ -110,7 +109,7 @@ where
                     console.log(credential);
                     htmx.ajax('POST', '{prefix}/tab/persona/webauthn/register_finish',
                         {{
-                            target: '#webauthnreg',
+                            target: '#passkeyreg',
                             values: {{
                                 json: JSON.stringify({{
                                     id: credential.id,
@@ -154,16 +153,12 @@ where
         serde_json::to_string(&hx_event).map_err(|err| AppError::Internal(err.into()))?;
 
     let html = html! {
-        div id="webauthnreg" {
+        div id="passkeyreg" {
             "registering.."
         }
     };
 
-    Ok((
-        [(HX_TRIGGER, HeaderValue::from_str(&hx_event_json).unwrap())],
-        html,
-    )
-        .into_response())
+    Ok(([(HX_TRIGGER, hx_event_json)], html).into_response())
 }
 
 /// This is an urlencoded form, which contains a JSON-encoded `RegisterPublicKeyCredential` inside.
@@ -199,9 +194,9 @@ where
     info!(?persona_id, "passkey registered");
 
     Ok((
-        [(HX_REFRESH, HeaderValue::from_static("true"))],
+        [(HX_REFRESH, "true")],
         html! {
-            div id="webauthnreg" {
+            div id="passkeyreg" {
                 "success!"
             }
         },

--- a/lib/authly-web/src/app/persona.rs
+++ b/lib/authly-web/src/app/persona.rs
@@ -1,9 +1,25 @@
-use authly_domain::extract::auth::WebAuth;
+use std::collections::BTreeMap;
+
+use authly_domain::{
+    ctx::{GetDb, WebAuthn},
+    extract::{auth::WebAuth, base_uri::ProxiedBaseUri},
+    webauthn,
+};
+use axum::{
+    extract::State,
+    response::{IntoResponse, Response},
+    Form,
+};
+use http::HeaderValue;
+use indoc::formatdoc;
 use maud::{html, Markup};
+use serde::{Deserialize, Serialize};
+use tracing::info;
 
 use crate::{
     app::tabs::{render_nav_tab_list, Tab},
-    Htmx,
+    htmx::HX_TRIGGER,
+    Authly, Htmx,
 };
 
 use super::{render_app_tab, AppError};
@@ -18,8 +34,118 @@ pub async fn persona(htmx: Htmx, auth: WebAuth<()>) -> Result<Markup, AppError> 
             (render_nav_tab_list(Tab::Persona, &prefix))
 
             div id="tab-content" role="tabpanel" class="tab-content" {
-                "entity ID: " code { (eid) }
+                div {
+                    "entity ID: " code { (eid) }
+                }
+
+                div id="webauthn" {
+                    button hx-post={(prefix)"/tab/persona/webauthn/register_start"} hx-target="#webauthn" {
+                        "Register WebAuthn token"
+                    }
+                }
             }
         },
+        Some(formatdoc! {
+            r#"
+            document.body.addEventListener('webauthnRegisterStart', function(evt) {{
+                console.log("registering");
+                const detail = evt.detail;
+
+                detail.publicKey.challenge = Base64.toUint8Array(detail.publicKey.challenge);
+                detail.publicKey.user.id = Base64.toUint8Array(detail.publicKey.user.id);
+                detail.publicKey.excludeCredentials?.forEach(function (listItem) {{
+                    listItem.id = Base64.toUint8Array(listItem.id)
+                }});
+
+                window.navigator.credentials.create(detail).then((credential) => {{
+                    console.log("registered");
+                    console.log(credential);
+                    htmx.ajax('POST', '{prefix}/tab/persona/webauthn/register_finish',
+                        {{
+                            target: '#webauthn',
+                            values: {{
+                                json: JSON.stringify({{
+                                    id: credential.id,
+                                    rawId: Base64.fromUint8Array(new Uint8Array(credential.rawId), true),
+                                    type: credential.type,
+                                    response: {{
+                                        attestationObject: Base64.fromUint8Array(new Uint8Array(credential.response.attestationObject), true),
+                                        clientDataJSON: Base64.fromUint8Array(new Uint8Array(credential.response.clientDataJSON), true),
+                                    }},
+                                }})
+                            }}
+                        }}
+                    );
+                }});
+            }});
+            "#,
+        }),
     ))
+}
+
+pub async fn webauthn_register_start(
+    State(Authly(ctx)): State<Authly<impl GetDb + WebAuthn>>,
+    base_uri: ProxiedBaseUri,
+    auth: WebAuth<()>,
+) -> Result<Response, AppError> {
+    let persona_id = auth
+        .claims
+        .authly
+        .entity_id
+        .try_into()
+        .map_err(|_| AppError::MustBePersona)?;
+
+    let challenge_response =
+        webauthn::webauthn_start_registration(&ctx, &base_uri.0, persona_id, "fixme.username")
+            .await
+            .map_err(|err| AppError::Internal(err.into()))?;
+    let hx_event = BTreeMap::from_iter([("webauthnRegisterStart", challenge_response)]);
+    let hx_event_json =
+        serde_json::to_string(&hx_event).map_err(|err| AppError::Internal(err.into()))?;
+
+    let html = html! {
+        div id="webauthn" {
+            "registering.."
+        }
+    };
+
+    Ok((
+        [(HX_TRIGGER, HeaderValue::from_str(&hx_event_json).unwrap())],
+        html,
+    )
+        .into_response())
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RegisterPublicKeyCredentialForm {
+    json: String,
+}
+
+pub async fn webauthn_register_finish(
+    State(Authly(ctx)): State<Authly<impl GetDb + WebAuthn>>,
+    base_uri: ProxiedBaseUri,
+    auth: WebAuth<()>,
+    Form(form): Form<RegisterPublicKeyCredentialForm>,
+) -> Result<Response, AppError> {
+    let persona_id = auth
+        .claims
+        .authly
+        .entity_id
+        .try_into()
+        .map_err(|_| AppError::MustBePersona)?;
+    let credential =
+        serde_json::from_str(&form.json).map_err(|err| AppError::InvalidInput(err.into()))?;
+
+    webauthn::webauthn_finish_registration(&ctx, &base_uri.0, persona_id, credential)
+        .await
+        .map_err(|err| AppError::Internal(err.into()))?;
+
+    info!("passkey registered for {persona_id}");
+
+    Ok(html! {
+        div id="webauthn" {
+            "success!"
+        }
+    }
+    .into_response())
 }

--- a/lib/authly-web/src/auth.rs
+++ b/lib/authly-web/src/auth.rs
@@ -1,19 +1,27 @@
+use std::collections::BTreeMap;
+
 use authly_common::mtls_server::PeerServiceEntity;
 use authly_domain::{
-    ctx::{GetBuiltins, GetDb, GetDecryptedDeks},
+    ctx::{GetBuiltins, GetDb, GetDecryptedDeks, WebAuthn},
     dev::IsDev,
-    extract::base_uri::ForwardedPrefix,
+    extract::base_uri::{ForwardedPrefix, ProxiedBaseUri},
     login::{try_username_password_login, LoginError, LoginOptions},
+    login_session::LoginSession,
+    session::Session,
+    webauthn::{self, PublicKeyCredential},
 };
 use axum::{
     extract::{Query, State},
     response::{IntoResponse, Response},
     Extension, Form,
 };
-use http::{HeaderName, HeaderValue};
-use maud::{html, Markup, DOCTYPE};
+use http::{HeaderValue, StatusCode, Uri};
+use indoc::formatdoc;
+use maud::{html, Markup, PreEscaped, DOCTYPE};
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
+
+use crate::htmx::{HX_REDIRECT, HX_TRIGGER};
 
 pub mod oauth;
 
@@ -25,35 +33,82 @@ pub struct QueryParams {
 
 pub async fn index(
     ForwardedPrefix(prefix): ForwardedPrefix,
+    login_session: LoginSession,
     Query(params): Query<QueryParams>,
-) -> Markup {
-    html! {
-        (DOCTYPE)
-        html {
-            head {
-                meta charset="utf-8";
-                meta name="viewport" content="device-width, intial-scale=1";
-                meta name="color-scheme" content="light dark";
-                title { "Authly sign in" }
-                script src={(prefix)"/static/vendor/htmx.min.js"} {}
-                link rel="shortcut icon" href={(prefix)"/static/favicon.svg"} type="image/svg+xml";
-                link rel="stylesheet" href={(prefix)"/static/vendor/pico.classless.min.css"};
-                link rel="stylesheet" href={(prefix)"/static/style.css"};
-                link rel="stylesheet" href={(prefix)"/static/auth.css"};
-            }
-            body {
-                div id="root" {
-                    main {
-                        img alt="Authly" src={(prefix)"/static/logo.svg"};
-                        div class="card" {
-                            h2 { "Sign in" }
-                            (login_form(&prefix, &params, None))
+) -> Response {
+    let webauthn_finish_url = format!(
+        "{prefix}/auth/webauthn/finish?{}",
+        &serde_urlencoded::to_string(&params).unwrap()
+    );
+
+    let js = formatdoc! {
+        r#"
+        document.body.addEventListener('webauthnAuthStart', function(evt) {{
+            const detail = evt.detail;
+
+            detail.publicKey.challenge = Base64.toUint8Array(detail.publicKey.challenge);
+            detail.publicKey.allowCredentials?.forEach(function (listItem) {{
+                listItem.id = Base64.toUint8Array(listItem.id)
+            }});
+
+            window.navigator.credentials.get({{ publicKey: detail.publicKey }}).then((assertion) => {{
+                htmx.ajax('POST', '{webauthn_finish_url}',
+                    {{
+                        target: '#loginform',
+                        values: {{
+                            json: JSON.stringify({{
+                                id: assertion.id,
+                                rawId: Base64.fromUint8Array(new Uint8Array(assertion.rawId), true),
+                                type: assertion.type,
+                                response: {{
+                                    authenticatorData: Base64.fromUint8Array(new Uint8Array(assertion.response.authenticatorData), true),
+                                    clientDataJSON: Base64.fromUint8Array(new Uint8Array(assertion.response.clientDataJSON), true),
+                                    signature: Base64.fromUint8Array(new Uint8Array(assertion.response.signature), true),
+                                    userHandle: Base64.fromUint8Array(new Uint8Array(assertion.response.userHandle), true)
+                                }},
+                            }})
+                        }}
+                    }}
+                );
+            }});
+        }});
+        "#
+    };
+
+    (
+        axum_extra::extract::CookieJar::new().add(login_session.to_cookie()),
+        html! {
+            (DOCTYPE)
+            html {
+                head {
+                    meta charset="utf-8";
+                    meta name="viewport" content="device-width, intial-scale=1";
+                    meta name="color-scheme" content="light dark";
+                    title { "Authly sign in" }
+                    script src={(prefix)"/static/vendor/htmx.min.js"} {}
+                    script src={(prefix)"/static/vendor/base64.min.js"} {}
+                    link rel="shortcut icon" href={(prefix)"/static/favicon.svg"} type="image/svg+xml";
+                    link rel="stylesheet" href={(prefix)"/static/vendor/pico.classless.min.css"};
+                    link rel="stylesheet" href={(prefix)"/static/style.css"};
+                    link rel="stylesheet" href={(prefix)"/static/auth.css"};
+                }
+                body {
+                    div id="root" {
+                        main {
+                            img alt="Authly" src={(prefix)"/static/logo.svg"};
+                            div class="card" {
+                                h2 { "Sign in" }
+                                (login_form(&prefix, &params, None))
+                            }
                         }
                     }
                 }
+
+                script { (PreEscaped(js)) }
             }
         }
-    }
+    )
+    .into_response()
 }
 
 /// A login form with an optional error message
@@ -64,22 +119,29 @@ fn login_form(prefix: &str, params: &QueryParams, message: Option<&str>) -> Mark
     );
 
     html!(
-        form hx-post={(login_url)} {
+        form id="loginform" hx-post={(login_url)} {
             div class="inputs" {
                 input id="username" name="username" type="text" aria-label="Username" placeholder="Username" required autofocus {}
-                input id="password" name="password" type="password" aria-label="Password" placeholder="Password" required {}
+                input id="password" name="password" type="password" aria-label="Password" placeholder="Password" {}
             }
             @if let Some(message) = message {
                 div class="error" {
                     (message)
                 }
             }
-            div {
-                button type="submit" {
+            div id="login_submit" {
+                button type="submit" name="action" value="login" {
                     svg {
                         use href={(prefix)"/static/vendor/login.svg#icon"};
                     }
                     "Sign in"
+                }
+
+                button type="submit" name="action" value="webauthn" {
+                    svg {
+                        use href={(prefix)"/static/vendor/login.svg#icon"};
+                    }
+                    "Passwordless"
                 }
             }
         }
@@ -90,48 +152,129 @@ fn login_form(prefix: &str, params: &QueryParams, message: Option<&str>) -> Mark
 // when the web auth routes are exposed on the internet.
 #[derive(Deserialize)]
 pub struct LoginBody {
+    action: String,
     username: String,
     password: String,
 }
 
-// NOTE: Uses response header `HX-redirect` (https://htmx.org/headers/hx-redirect/)
+#[allow(clippy::too_many_arguments)]
 pub async fn login<Ctx>(
     State(ctx): State<Ctx>,
     Extension(peer_svc): Extension<PeerServiceEntity>,
+    login_session: LoginSession,
     is_dev: IsDev,
+    base_uri: ProxiedBaseUri,
     ForwardedPrefix(prefix): ForwardedPrefix,
     Query(params): Query<QueryParams>,
-    Form(LoginBody { username, password }): Form<LoginBody>,
+    Form(LoginBody {
+        action,
+        username,
+        password,
+    }): Form<LoginBody>,
 ) -> Response
 where
-    Ctx: GetDb + GetBuiltins + GetDecryptedDeks,
+    Ctx: GetDb + GetBuiltins + GetDecryptedDeks + WebAuthn,
 {
-    let login_options = LoginOptions::default().dev(is_dev);
+    /// Produce a "hx-trigger" header value that starts webauthn auth flow
+    async fn webauthn_start_event(
+        ctx: &(impl WebAuthn + GetDb + GetDecryptedDeks),
+        base_uri: &Uri,
+        login_session: LoginSession,
+        username: &str,
+    ) -> anyhow::Result<HeaderValue> {
+        let challenge_response =
+            webauthn::webauthn_start_authentication(ctx, base_uri, login_session.0, username)
+                .await?;
+        let hx_event = BTreeMap::from_iter([("webauthnAuthStart", challenge_response)]);
+        let hx_event_json = serde_json::to_string(&hx_event)?;
 
-    match try_username_password_login(&ctx, peer_svc, username, password, login_options).await {
-        Ok((_persona_id, session)) => (
-            axum_extra::extract::CookieJar::new().add(session.to_cookie()),
-            [(
-                HeaderName::from_static("hx-redirect"),
-                HeaderValue::from_str(&params.next).unwrap_or_else(|err| {
-                    warn!(
-                        ?err,
-                        ?params,
-                        "client tried to fool us with a misformatted redirect url"
-                    );
-                    HeaderValue::from_static("")
-                }),
-            )],
-        )
-            .into_response(),
-        Err(err) => {
-            match err {
-                LoginError::UnprivilegedService => info!("unprivileged service"),
-                LoginError::Credentials => {}
-                LoginError::Db(err) => warn!(?err, "login db error"),
+        Ok(HeaderValue::from_str(&hx_event_json)?)
+    }
+
+    match action.as_str() {
+        "login" => {
+            let login_options = LoginOptions::default().dev(is_dev);
+
+            match try_username_password_login(&ctx, peer_svc, username, password, login_options)
+                .await
+            {
+                Ok((_persona_id, session)) => login_success_redirect(session, &params),
+                Err(err) => {
+                    match err {
+                        LoginError::UnprivilegedService => info!("unprivileged service"),
+                        LoginError::Credentials => {}
+                        LoginError::Db(err) => warn!(?err, "login db error"),
+                    }
+
+                    login_form(&prefix, &params, Some("Invalid username or password"))
+                        .into_response()
+                }
             }
+        }
+        "webauthn" => {
+            match webauthn_start_event(&ctx, &base_uri.0, login_session, &username).await {
+                Ok(trigger_event_value) => (
+                    [(HX_TRIGGER, trigger_event_value)],
+                    login_form(&prefix, &params, None),
+                )
+                    .into_response(),
+                Err(err) => {
+                    tracing::error!(?err, "webauthn auth");
 
-            login_form(&prefix, &params, Some("Invalid username or password")).into_response()
+                    login_form(&prefix, &params, Some("Webauthn error")).into_response()
+                }
+            }
+        }
+        _ => login_form(&prefix, &params, Some("Invalid login action")).into_response(),
+    }
+}
+
+fn login_success_redirect(session: Session, params: &QueryParams) -> Response {
+    (
+        axum_extra::extract::CookieJar::new().add(session.to_cookie()),
+        [(
+            HX_REDIRECT,
+            HeaderValue::from_str(&params.next).unwrap_or_else(|err| {
+                warn!(
+                    ?err,
+                    ?params,
+                    "client tried to fool us with a misformatted redirect url"
+                );
+                HeaderValue::from_static("")
+            }),
+        )],
+    )
+        .into_response()
+}
+
+#[derive(Deserialize)]
+pub struct PublicKeyCredentialForm {
+    /// The PublicKeyCredential JSON string
+    json: String,
+}
+
+pub async fn webauthn_auth_finish<Ctx>(
+    State(ctx): State<Ctx>,
+    Extension(_peer_svc): Extension<PeerServiceEntity>,
+    login_session: LoginSession,
+    base_uri: ProxiedBaseUri,
+    ForwardedPrefix(prefix): ForwardedPrefix,
+    Query(params): Query<QueryParams>,
+    Form(PublicKeyCredentialForm { json }): Form<PublicKeyCredentialForm>,
+) -> Result<Response, (StatusCode, String)>
+where
+    Ctx: GetDb + WebAuthn + GetBuiltins,
+{
+    let credential = serde_json::from_str::<PublicKeyCredential>(&json)
+        .map_err(|err| (StatusCode::UNPROCESSABLE_ENTITY, format!("{err:?}")))?;
+
+    match webauthn::webauthn_finish_authentication(&ctx, &base_uri.0, login_session.0, credential)
+        .await
+    {
+        Ok((_persona_id, session)) => Ok(login_success_redirect(session, &params)),
+        Err(err) => {
+            info!(?err, "webauthn auth finish error");
+            Ok(login_form(&prefix, &params, Some("webauthn auth error")).into_response())
         }
     }
 }

--- a/lib/authly-web/src/auth/oauth.rs
+++ b/lib/authly-web/src/auth/oauth.rs
@@ -9,7 +9,7 @@ use authly_domain::{
     session::init_session,
 };
 use axum::{
-    extract::{FromRef, Path, Query, State},
+    extract::{Path, Query, State},
     response::{IntoResponse, Response},
 };
 use axum_extra::extract::CookieJar;
@@ -18,16 +18,7 @@ use rand::{rngs::OsRng, Rng};
 use reqwest::Url;
 use tracing::warn;
 
-pub struct OAuthState<Ctx>(pub Ctx);
-
-impl<Ctx> FromRef<Ctx> for OAuthState<Ctx>
-where
-    Ctx: GetDb + Directories + Clone,
-{
-    fn from_ref(input: &Ctx) -> Self {
-        Self(input.clone())
-    }
-}
+use crate::Authly;
 
 #[derive(Debug)]
 pub enum OAuthError {
@@ -72,9 +63,7 @@ impl IntoResponse for OAuthError {
 }
 
 pub async fn oauth_callback(
-    State(OAuthState(ctx)): State<
-        OAuthState<impl GetDb + Directories + GetHttpClient + GetDecryptedDeks>,
-    >,
+    State(Authly(ctx)): State<Authly<impl GetDb + Directories + GetHttpClient + GetDecryptedDeks>>,
     base_uri: ProxiedBaseUri,
     Path(label): Path<String>,
     query: Query<BTreeMap<String, String>>,

--- a/lib/authly-web/src/lib.rs
+++ b/lib/authly-web/src/lib.rs
@@ -7,7 +7,6 @@ use authly_domain::{
 use authly_webstatic::static_folder;
 use axum::{
     async_trait,
-    extract::FromRef,
     routing::{get, post},
 };
 use http::request::Parts;
@@ -37,40 +36,36 @@ where
         .route("/tab/persona", get(app::persona::persona))
         .route(
             "/tab/persona/webauthn/register_start",
-            post(app::persona::webauthn_register_start),
+            post(app::persona::webauthn_register_start::<Ctx>),
         )
         .route(
             "/tab/persona/webauthn/register_finish",
-            post(app::persona::webauthn_register_finish),
+            post(app::persona::webauthn_register_finish::<Ctx>),
         )
         .route("/auth", get(auth::index))
         .route("/auth/login", post(auth::login::<Ctx>))
         .route(
+            "/auth/webauthn/finish",
+            post(auth::webauthn_auth_finish::<Ctx>),
+        )
+        .route(
             "/auth/oauth/:label/callback",
-            post(auth::oauth::oauth_callback),
+            post(auth::oauth::oauth_callback::<Ctx>),
         )
         .nest_service("/static", static_folder())
-}
-
-pub struct Authly<Ctx>(pub Ctx);
-
-impl<Ctx> FromRef<Ctx> for Authly<Ctx>
-where
-    Ctx: GetDb + Directories + Clone,
-{
-    fn from_ref(input: &Ctx) -> Self {
-        Self(input.clone())
-    }
 }
 
 mod htmx {
     use http::HeaderName;
 
+    /// https://htmx.org/headers/hx-redirect/
     pub const HX_REDIRECT: HeaderName = HeaderName::from_static("hx-redirect");
 
+    /// https://htmx.org/attributes/hx-request/
     #[expect(unused)]
     pub const HX_REQUEST: HeaderName = HeaderName::from_static("hx-request");
 
+    /// https://htmx.org/headers/hx-trigger/
     pub const HX_TRIGGER: HeaderName = HeaderName::from_static("hx-trigger");
 }
 

--- a/lib/authly-web/src/lib.rs
+++ b/lib/authly-web/src/lib.rs
@@ -33,7 +33,7 @@ where
 {
     axum::Router::new()
         .route("/", get(app::index))
-        .route("/tab/persona", get(app::persona::persona))
+        .route("/tab/persona", get(app::persona::persona::<Ctx>))
         .route(
             "/tab/persona/webauthn/register_start",
             post(app::persona::webauthn_register_start::<Ctx>),
@@ -67,6 +67,9 @@ mod htmx {
 
     /// https://htmx.org/headers/hx-trigger/
     pub const HX_TRIGGER: HeaderName = HeaderName::from_static("hx-trigger");
+
+    /// https://htmx.org/reference/#response_headers
+    pub const HX_REFRESH: HeaderName = HeaderName::from_static("hx-refresh");
 }
 
 #[derive(Clone)]

--- a/lib/authly-web/src/tests/test_oauth.rs
+++ b/lib/authly-web/src/tests/test_oauth.rs
@@ -25,7 +25,7 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::auth::oauth::OAuthState;
+use crate::Authly;
 
 fn random_oauth(dir_id: DirectoryId, dir_key: DirKey) -> OAuthDirectory {
     fn rnd() -> String {
@@ -330,7 +330,7 @@ async fn test_callback_github_like() {
         .await;
 
     let _result = crate::auth::oauth::oauth_callback(
-        State(OAuthState(ctx)),
+        State(Authly(ctx)),
         ProxiedBaseUri("http://localhost".parse().unwrap()),
         Path("buksehub".to_string()),
         Query([("code".to_string(), code.to_string())].into()),

--- a/lib/authly-web/src/tests/test_oauth.rs
+++ b/lib/authly-web/src/tests/test_oauth.rs
@@ -25,8 +25,6 @@ use wiremock::{
     Mock, ResponseTemplate,
 };
 
-use crate::Authly;
-
 fn random_oauth(dir_id: DirectoryId, dir_key: DirKey) -> OAuthDirectory {
     fn rnd() -> String {
         let mut bytes = [0; 8];
@@ -330,7 +328,7 @@ async fn test_callback_github_like() {
         .await;
 
     let _result = crate::auth::oauth::oauth_callback(
-        State(Authly(ctx)),
+        State(ctx),
         ProxiedBaseUri("http://localhost".parse().unwrap()),
         Path("buksehub".to_string()),
         Query([("code".to_string(), code.to_string())].into()),

--- a/lib/authly-webstatic/static/auth.css
+++ b/lib/authly-webstatic/static/auth.css
@@ -20,6 +20,10 @@ main {
   justify-content: space-between;
 }
 
+.inputs>input {
+  margin-bottom: 0px;
+}
+
 .card {
   display: grid;
   gap: 16px;
@@ -44,6 +48,7 @@ main {
   display: grid;
   gap: 8px;
 }
+
 
 .card button {
   width: auto;

--- a/lib/authly-webstatic/static/auth.css
+++ b/lib/authly-webstatic/static/auth.css
@@ -15,6 +15,11 @@ main {
   gap: 64px;
 }
 
+#login_submit {
+  display: flex;
+  justify-content: space-between;
+}
+
 .card {
   display: grid;
   gap: 16px;

--- a/lib/authly-webstatic/static/style.css
+++ b/lib/authly-webstatic/static/style.css
@@ -9,11 +9,13 @@
   --pico-outline-width: 1px;
   --pico-form-element-spacing-vertical: 8px;
   --pico-form-element-spacing-horizontal: 8px;
-  --pico-spacing: 0;
 }
 
 :root:not([data-theme="dark"]) {
+  /*
+  Didn't understand why this was here, it made text unreadable on dark mode
   --pico-color: rgb(48, 48, 48);
+  */
   --pico-primary: rgb(48, 48, 48);
   --pico-primary-background: rgb(16, 16, 16);
   --pico-primary-border: rgb(48, 48, 48);

--- a/lib/authly-webstatic/update.sh
+++ b/lib/authly-webstatic/update.sh
@@ -3,6 +3,7 @@ mkdir -p static/vendor
 curl -O --output-dir ./static/vendor https://unpkg.com/@picocss/pico@2.0.6/css/pico.classless.min.css
 curl -O --output-dir ./static/vendor https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js
 curl -O --output-dir ./static/vendor https://unpkg.com/htmx-ext-json-enc@2.0.1/json-enc.js
+curl -O --output-dir ./static/vendor https://cdn.jsdelivr.net/npm/js-base64@3.7.4/base64.min.js
 curl -O --output-dir ./static/vendor https://unpkg.com/@carbon/icons@11.53.0/svg/32/login.svg
 curl -O --output-dir ./static/vendor https://rsms.me/inter/font-files/InterVariable.woff2
 curl -O --output-dir ./static/vendor https://rsms.me/inter/font-files/InterVariable-Italic.woff2

--- a/lib/authly-webstatic/update.sh
+++ b/lib/authly-webstatic/update.sh
@@ -4,6 +4,7 @@ curl -O --output-dir ./static/vendor https://unpkg.com/@picocss/pico@2.0.6/css/p
 curl -O --output-dir ./static/vendor https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js
 curl -O --output-dir ./static/vendor https://unpkg.com/htmx-ext-json-enc@2.0.1/json-enc.js
 curl -O --output-dir ./static/vendor https://cdn.jsdelivr.net/npm/js-base64@3.7.4/base64.min.js
+curl --output ./static/vendor/relative-time-element-bundle.js https://unpkg.com/@github/relative-time-element@4.4.5/dist/bundle.js
 curl -O --output-dir ./static/vendor https://unpkg.com/@carbon/icons@11.53.0/svg/32/login.svg
 curl -O --output-dir ./static/vendor https://rsms.me/inter/font-files/InterVariable.woff2
 curl -O --output-dir ./static/vendor https://rsms.me/inter/font-files/InterVariable-Italic.woff2


### PR DESCRIPTION
Builds on [webauthn-rs](https://docs.rs/webauthn-rs/latest/webauthn_rs/).

The plan is to make a token registration UI in the self-service part of authly-web. In a web client context, this somehow needs to interact with the Web Authentication JS API, both the registration and the authentication flows.

It is not possible to bootstrap new users with pre-existing passkeys through configuration (as we can do with passwords). If an authly-based system wanted to be primarily passkey-based, the bootstrapped users would need to use a one-time password that's sent over email, perhaps a magic link. Once inside Authly UI, the first passkey can be registered.

Followup:
1. Added a button that registers a new passkey in the Authly web app
2. Added a button for passwordless login in the Auth UI
3. Added a list of registered passkeys