### PR TITLE
chore: upgrade axum, maud, authly-lib and tonic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cf008e5e1a9e9e22a7d3c9a4992e21a350290069e36d8fb72304ed17e8f2d2"
+checksum = "59a194f9d963d8099596278594b3107448656ba73831c9d8c783e613ce86da64"
 dependencies = [
  "brotli",
  "futures-core",
@@ -358,7 +358,7 @@ dependencies = [
  "authly-secrets",
  "authly-service",
  "authly-web",
- "axum 0.7.9",
+ "axum",
  "axum-extra",
  "blake3",
  "clap",
@@ -369,7 +369,7 @@ dependencies = [
  "hostname",
  "http",
  "hyper",
- "indexmap 2.8.0",
+ "indexmap",
  "indoc",
  "int-enum",
  "jsonwebtoken",
@@ -395,7 +395,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tonic",
- "tower 0.5.2",
+ "tower",
  "tower-server",
  "tracing",
  "tracing-subscriber",
@@ -405,7 +405,7 @@ dependencies = [
 [[package]]
 name = "authly-client"
 version = "0.0.8"
-source = "git+https://github.com/protojour/authly-lib.git#7bce336bcff599613f6bde3165c68d7892a12025"
+source = "git+https://github.com/protojour/authly-lib.git#31faf6d5c8c3e02d196c3ef46f1ca306da0f7a0d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -432,7 +432,7 @@ dependencies = [
 [[package]]
 name = "authly-common"
 version = "0.0.8"
-source = "git+https://github.com/protojour/authly-lib.git#7bce336bcff599613f6bde3165c68d7892a12025"
+source = "git+https://github.com/protojour/authly-lib.git#31faf6d5c8c3e02d196c3ef46f1ca306da0f7a0d"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -464,7 +464,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "authly-common",
- "axum 0.7.9",
+ "axum",
  "futures-util",
  "http",
  "hyper",
@@ -474,7 +474,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tonic",
- "tower 0.5.2",
+ "tower",
  "tower-server",
  "tracing",
 ]
@@ -503,7 +503,7 @@ dependencies = [
  "async-trait",
  "authly-common",
  "authly-db",
- "axum 0.7.9",
+ "axum",
  "axum-extra",
  "base64 0.22.1",
  "blake3",
@@ -513,7 +513,7 @@ dependencies = [
  "hexhex",
  "http",
  "humantime",
- "indexmap 2.8.0",
+ "indexmap",
  "indoc",
  "int-enum",
  "itertools 0.14.0",
@@ -579,7 +579,7 @@ dependencies = [
  "authly-connect",
  "authly-db",
  "authly-domain",
- "axum 0.7.9",
+ "axum",
  "axum-extra",
  "blake3",
  "bytes",
@@ -628,7 +628,7 @@ dependencies = [
  "authly-service",
  "authly-sqlite",
  "authly-test-grpc",
- "axum 0.7.9",
+ "axum",
  "cookie",
  "criterion",
  "fnv",
@@ -636,7 +636,7 @@ dependencies = [
  "hexhex",
  "http",
  "hyper-util",
- "indexmap 2.8.0",
+ "indexmap",
  "indoc",
  "itertools 0.14.0",
  "rcgen 0.13.3",
@@ -677,7 +677,7 @@ version = "0.0.0"
 dependencies = [
  "authly-client",
  "authly-common",
- "axum 0.7.9",
+ "axum",
  "axum-extra",
  "futures-util",
  "indoc",
@@ -699,12 +699,12 @@ dependencies = [
  "authly-domain",
  "authly-test",
  "authly-webstatic",
- "axum 0.7.9",
+ "axum",
  "axum-extra",
  "fnv",
  "hexhex",
  "http",
- "indexmap 2.8.0",
+ "indexmap",
  "indoc",
  "itertools 0.14.0",
  "maud",
@@ -742,7 +742,7 @@ dependencies = [
 name = "authly-webstatic"
 version = "0.0.0"
 dependencies = [
- "axum 0.7.9",
+ "axum",
  "http",
  "mime_guess",
  "rust-embed",
@@ -779,46 +779,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "axum-macros",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
 dependencies = [
- "axum-core 0.5.0",
+ "axum-core",
+ "axum-macros",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -828,7 +794,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -840,28 +806,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -889,34 +834,32 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
+checksum = "460fc6f625a1f7705c6cf62d0d070794e94668988b1c38111baeec177c715f7b"
 dependencies = [
- "axum 0.7.9",
- "axum-core 0.4.5",
+ "axum",
+ "axum-core",
  "bytes",
  "cookie",
- "fastrand",
  "futures-util",
  "headers",
  "http",
  "http-body",
  "http-body-util",
  "mime",
- "multer",
  "pin-project-lite",
  "serde",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-macros"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1037,7 +980,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -1126,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b74d67a0fc0af8e9823b79fd1c43a0900e5a8f0e0f4cc9210796bf3a820126"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -1136,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d37ed1b2c9b78421218a0b4f6d8349132d6ec2cfeba1cfb0118b0a8e268df9e"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -1731,15 +1674,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,7 +1741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "305d3ba574508e27190906d11707dad683e0494e6b85eae9b044cb2734a5e422"
 dependencies = [
  "async-trait",
- "axum-core 0.5.0",
+ "axum-core",
  "base64 0.21.7",
  "bytes",
  "http",
@@ -2062,7 +1996,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.8.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2196,7 +2130,7 @@ name = "hiqlite"
 version = "0.5.0"
 source = "git+https://github.com/sebadob/hiqlite.git#57e11d60b04bcea887bc270ad9157207b3434d50"
 dependencies = [
- "axum 0.8.1",
+ "axum",
  "axum-server",
  "bincode 2.0.1",
  "byteorder",
@@ -2578,16 +2512,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
@@ -2657,6 +2581,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -2788,7 +2721,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tower-http",
  "tracing",
 ]
@@ -2945,23 +2878,17 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maud"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df518b75016b4289cdddffa1b01f2122f4a49802c93191f3133f6dc2472ebcaa"
+checksum = "8156733e27020ea5c684db5beac5d1d611e1272ab17901a49466294b84fc217e"
 dependencies = [
- "axum-core 0.4.5",
+ "axum-core",
  "http",
  "itoa",
  "maud_macros",
@@ -2969,12 +2896,12 @@ dependencies = [
 
 [[package]]
 name = "maud_macros"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa453238ec218da0af6b11fc5978d3b5c3a45ed97b722391a2a11f3306274e18"
+checksum = "7261b00f3952f617899bc012e3dbd56e4f0110a038175929fa5d18e5a19913ca"
 dependencies = [
- "proc-macro-error",
  "proc-macro2",
+ "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.100",
 ]
@@ -3040,23 +2967,6 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "version_check",
 ]
 
 [[package]]
@@ -3368,9 +3278,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -3379,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3389,9 +3299,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3402,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -3418,7 +3328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.8.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -3529,29 +3439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3647,9 +3534,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.2"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+checksum = "bf763ab1c7a3aa408be466efc86efe35ed1bd3dd74173ed39d6b0d0a6f0ba148"
 dependencies = [
  "memchr",
  "serde",
@@ -3697,9 +3584,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
+checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3905,7 +3792,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4149,9 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.0"
+version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4397,7 +4284,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -4831,7 +4718,7 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4840,13 +4727,12 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "85839f0b32fd242bb3209262371d07feda6d780d16ee9d2bc88581b89da1549b"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -4859,12 +4745,11 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "rustls-pemfile",
  "socket2",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4872,9 +4757,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "d85f0383fadd15609306383a90e85eaed44169f931a5d2be1b42c76ceff1825e"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -4886,33 +4771,15 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
  "tokio-util",

--- a/bin/authly-testservice/Cargo.toml
+++ b/bin/authly-testservice/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 [dependencies]
 authly-client = { workspace = true, features = ["rustls_023"] }
 authly-common = { workspace = true, features = ["mtls_server"] }
-axum = "0.7"
-axum-extra = { version = "0.9", features = ["cookie", "typed-header"] }
+axum = "0.8"
+axum-extra = { version = "0.10", features = ["cookie", "typed-header"] }
 futures-util = "0.3"
 indoc = "2"
-maud = { version = "0.26", features = ["axum"] }
+maud = { version = "0.27", features = ["axum"] }
 rustls = { version = "0.23", default-features = false }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 tower-server = { workspace = true, features = ["signal"] }

--- a/bin/authly-testservice/src/main.rs
+++ b/bin/authly-testservice/src/main.rs
@@ -394,7 +394,6 @@ struct HtmlCtx {
     prefix: String,
 }
 
-#[axum::async_trait]
 impl axum::extract::FromRequestParts<Ctx> for HtmlCtx {
     type Rejection = Error;
 

--- a/bin/authly/Cargo.toml
+++ b/bin/authly/Cargo.toml
@@ -34,8 +34,8 @@ authly-web = { path = "../../lib/authly-web" }
 aes-gcm-siv = "0.11"
 anyhow = "1"
 arc-swap = "1.7"
-axum = { version = "0.7", features = ["macros"] }
-axum-extra = { version = "0.9", features = ["typed-header"] }
+axum = { version = "0.8", features = ["macros"] }
+axum-extra = { version = "0.10", features = ["typed-header"] }
 blake3 = "1.5"
 clap = { version = "4", features = ["derive"] }
 figment = { version = "0.10", features = ["env"] }
@@ -73,7 +73,7 @@ time = { version = "0.3", features = ["serde"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
 tokio-rustls = "0.26"
 tokio-util = { version = "0.7", features = ["io"] }
-tonic = { version = "0.12", default-features = false }
+tonic = { version = "0.13", default-features = false, features = ["router"] }
 tower = { version = "0.5", features = ["steer"] }
 tower-server = { workspace = true, features = ["signal"] }
 tracing = "0.1"

--- a/deny.toml
+++ b/deny.toml
@@ -28,8 +28,6 @@ feature-depth = 1
 # https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 ignore = [
-    # FIXME: proc-macro-error (fixed on `maud` upgrade):
-    "RUSTSEC-2024-0370",
     # FIXME: "paste" is unmaintained:
     "RUSTSEC-2024-0436",
 ]
@@ -101,18 +99,10 @@ deny = []
 skip = [
     # because of (temporary) git dependency:
     "rcgen",
-    # because of (temporary) outdated axum:
-    "axum",
-    "axum-core",
-    "matchit",
     # because crypto libraries require older "rand", authly still uses rand 0.8:
     "rand",
     "rand_chacha",
     "rand_core",
-    # FIXME (tower 0.4):
-    "tower",
-    "indexmap",
-    "hashbrown",
     # FIXME: hexhex:
     "fallible-iterator",
     # FIXME: hiqlite/cryptr:

--- a/lib/authly-connect/Cargo.toml
+++ b/lib/authly-connect/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 authly-common = { workspace = true, features = ["tonic_server"] }
 anyhow = "1"
-axum = { version = "0.7", features = ["macros"] }
+axum = { version = "0.8", features = ["macros"] }
 futures-util = "0.3"
 http = "1"
 hyper = { version = "1", default-features = false }
@@ -24,7 +24,7 @@ rustls = { version = "0.23", default-features = false }
 tokio = { version = "1" }
 tokio-rustls = "0.26"
 tokio-util = { version = "0.7", features = ["io"] }
-tonic = { version = "0.12", default-features = false }
+tonic = { version = "0.13", default-features = false }
 tower = { version = "0.5", features = ["buffer", "steer"] }
 tower-server.workspace = true
 tracing = "0.1"

--- a/lib/authly-connect/src/tunnel.rs
+++ b/lib/authly-connect/src/tunnel.rs
@@ -64,7 +64,7 @@ pub async fn authly_connect_client_tunnel<T>(
     close_signal: CancellationToken,
 ) -> tonic::Result<ClientSideTunnel>
 where
-    T: tonic::client::GrpcService<tonic::body::BoxBody>,
+    T: tonic::client::GrpcService<tonic::body::Body>,
     T::Error: Into<StdError>,
     T::ResponseBody: Body<Data = Bytes> + std::marker::Send + 'static,
     <T::ResponseBody as Body>::Error: Into<StdError> + std::marker::Send,

--- a/lib/authly-domain/Cargo.toml
+++ b/lib/authly-domain/Cargo.toml
@@ -21,8 +21,8 @@ authly-common = { workspace = true, features = [
 ] }
 aes-gcm-siv = { version = "0.11", features = ["std"] }
 async-trait = "0.1"
-axum = { version = "0.7", features = ["macros"] }
-axum-extra = { version = "0.9", features = ["cookie", "typed-header"] }
+axum = { version = "0.8", features = ["macros"] }
+axum-extra = { version = "0.10", features = ["cookie", "typed-header"] }
 anyhow = "1"
 argon2 = "0.5"
 arc-swap = "1.7"

--- a/lib/authly-domain/src/access_token.rs
+++ b/lib/authly-domain/src/access_token.rs
@@ -82,8 +82,7 @@ pub struct VerifiedAccessToken {
     pub claims: AuthlyAccessTokenClaims,
 }
 
-#[axum::async_trait]
-impl<Ctx> axum::extract::FromRequestParts<Ctx> for VerifiedAccessToken
+impl<Ctx: Sync> axum::extract::FromRequestParts<Ctx> for VerifiedAccessToken
 where
     Ctx: GetInstance + Send + Sync,
 {

--- a/lib/authly-domain/src/dev.rs
+++ b/lib/authly-domain/src/dev.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use axum::extract::FromRequestParts;
 use http::request::Parts;
 
@@ -6,8 +5,7 @@ use http::request::Parts;
 #[derive(Clone, Copy)]
 pub struct IsDev(pub bool);
 
-#[async_trait]
-impl<S> FromRequestParts<S> for IsDev {
+impl<S: Sync> FromRequestParts<S> for IsDev {
     type Rejection = ();
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {

--- a/lib/authly-domain/src/extract/auth.rs
+++ b/lib/authly-domain/src/extract/auth.rs
@@ -35,7 +35,6 @@ pub struct WebAuth<R: VerifyAuthlyRole> {
     _phantom: PhantomData<R>,
 }
 
-#[axum::async_trait]
 impl<Ctx, R: VerifyAuthlyRole> axum::extract::FromRequestParts<Ctx> for ApiAuth<R>
 where
     Ctx: GetDb + GetInstance + Send + Sync,
@@ -50,7 +49,6 @@ where
     }
 }
 
-#[axum::async_trait]
 impl<Ctx, R: VerifyAuthlyRole> axum::extract::FromRequestParts<Ctx> for WebAuth<R>
 where
     Ctx: GetDb + GetInstance + Send + Sync,

--- a/lib/authly-domain/src/extract/base_uri.rs
+++ b/lib/authly-domain/src/extract/base_uri.rs
@@ -19,8 +19,7 @@ impl Display for ProxiedUri {
     }
 }
 
-#[axum::async_trait]
-impl<S> axum::extract::FromRequestParts<S> for ProxiedUri {
+impl<S: Sync> axum::extract::FromRequestParts<S> for ProxiedUri {
     type Rejection = ();
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
@@ -42,8 +41,7 @@ impl Display for ProxiedBaseUri {
     }
 }
 
-#[axum::async_trait]
-impl<S> axum::extract::FromRequestParts<S> for ProxiedBaseUri {
+impl<S: Sync> axum::extract::FromRequestParts<S> for ProxiedBaseUri {
     type Rejection = ();
 
     async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
@@ -70,8 +68,7 @@ impl<S> axum::extract::FromRequestParts<S> for ProxiedBaseUri {
 #[derive(Default)]
 pub struct ForwardedPrefix(pub String);
 
-#[axum::async_trait]
-impl<S> axum::extract::FromRequestParts<S> for ForwardedPrefix {
+impl<S: Sync> axum::extract::FromRequestParts<S> for ForwardedPrefix {
     type Rejection = ();
 
     /// Perform the extraction.

--- a/lib/authly-domain/src/login_session.rs
+++ b/lib/authly-domain/src/login_session.rs
@@ -20,7 +20,6 @@ impl LoginSession {
     }
 }
 
-#[axum::async_trait]
 impl<S: Send + Sync> axum::extract::FromRequestParts<S> for LoginSession {
     type Rejection = ();
 

--- a/lib/authly-service/Cargo.toml
+++ b/lib/authly-service/Cargo.toml
@@ -23,8 +23,8 @@ authly-common = { workspace = true, features = [
 ] }
 
 anyhow = "1"
-axum = { version = "0.7", features = ["macros"] }
-axum-extra = { version = "0.9", features = ["cookie", "typed-header"] }
+axum = { version = "0.8", features = ["macros"] }
+axum-extra = { version = "0.10", features = ["cookie", "typed-header"] }
 blake3 = "1.5"
 bytes = "1"
 futures-util = "0.3"
@@ -39,7 +39,7 @@ serde = "1"
 serde_json = "1"
 thiserror = "2"
 time = { version = "0.3", features = ["serde"] }
-tonic = { version = "0.12", default-features = false }
+tonic = { version = "0.13", default-features = false }
 tokio = { version = "1", features = ["macros"] }
 tokio-stream = "0.1"
 tokio-util = { version = "0.7" }

--- a/lib/authly-test-grpc/Cargo.toml
+++ b/lib/authly-test-grpc/Cargo.toml
@@ -14,10 +14,10 @@ doctest = false
 
 [dependencies]
 prost = "0.13"
-tonic = { version = "0.12", default-features = false, features = [
+tonic = { version = "0.13", default-features = false, features = [
     "prost",
     "codegen",
 ] }
 
 [build-dependencies]
-tonic-build = "0.12"
+tonic-build = "0.13"

--- a/lib/authly-test/Cargo.toml
+++ b/lib/authly-test/Cargo.toml
@@ -24,7 +24,7 @@ authly-common = { workspace = true, features = [
 ] }
 anyhow = "1"
 arc-swap = "1.7"
-axum = { version = "0.7", features = ["macros"] }
+axum = { version = "0.8", features = ["macros"] }
 http = "1"
 indexmap = "2.7"
 indoc = "2"
@@ -39,7 +39,7 @@ serde_spanned = "0.6"
 time = "0.3"
 tokio = { version = "1", features = ["macros"] }
 tokio-util = { version = "0.7" }
-tonic = { version = "0.12", default-features = false }
+tonic = { version = "0.13", default-features = false, features = ["router"] }
 tower-server.workspace = true
 tracing = "0.1"
 uuid = "1"

--- a/lib/authly-web/Cargo.toml
+++ b/lib/authly-web/Cargo.toml
@@ -16,8 +16,8 @@ doctest = false
 authly-domain = { path = "../authly-domain" }
 authly-webstatic = { path = "../authly-webstatic" }
 authly-common.workspace = true
-axum = { version = "0.7", features = ["macros"] }
-axum-extra = { version = "0.9", features = ["cookie", "typed-header"] }
+axum = { version = "0.8", features = ["macros"] }
+axum-extra = { version = "0.10", features = ["cookie", "typed-header"] }
 anyhow = "1"
 fnv = "1"
 hexhex = "1"
@@ -25,7 +25,7 @@ http = "1"
 indexmap = "2.7"
 indoc = "2"
 itertools = "0.14"
-maud = { version = "0.26", features = ["axum"] }
+maud = { version = "0.27", features = ["axum"] }
 rand = "0.8"
 reqwest.workspace = true
 serde = { version = "1", features = ["derive"] }

--- a/lib/authly-web/src/lib.rs
+++ b/lib/authly-web/src/lib.rs
@@ -5,10 +5,7 @@ use authly_domain::{
     extract::base_uri::ForwardedPrefix,
 };
 use authly_webstatic::static_folder;
-use axum::{
-    async_trait,
-    routing::{get, post},
-};
+use axum::routing::{get, post};
 use http::request::Parts;
 
 pub mod app;
@@ -50,7 +47,7 @@ where
             post(auth::webauthn_auth_finish::<Ctx>),
         )
         .route(
-            "/auth/oauth/:label/callback",
+            "/auth/oauth/{label}/callback",
             post(auth::oauth::oauth_callback::<Ctx>),
         )
         .nest_service("/static", static_folder())
@@ -79,7 +76,6 @@ pub struct Htmx {
     prefix: String,
 }
 
-#[async_trait]
 impl<S: Sync> axum::extract::FromRequestParts<S> for Htmx {
     type Rejection = ();
 

--- a/lib/authly-webstatic/Cargo.toml
+++ b/lib/authly-webstatic/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 doctest = false
 
 [dependencies]
-axum = { version = "0.7", features = ["macros"] }
+axum = { version = "0.8", features = ["macros"] }
 http = "1"
 mime_guess = "2"
 rust-embed = "8"


### PR DESCRIPTION
With the release of tonic 0.13, all of these libraries can be upgraded (tonic has a tight integration with axum and uses its router)